### PR TITLE
Added support for child in place editor configurations in _cq_editConfig.xml

### DIFF
--- a/cq-component-annotations/src/main/java/com/citytechinc/cq/component/annotations/Component.java
+++ b/cq-component-annotations/src/main/java/com/citytechinc/cq/component/annotations/Component.java
@@ -16,6 +16,7 @@
 package com.citytechinc.cq.component.annotations;
 
 import com.citytechinc.cq.component.annotations.editconfig.ActionConfig;
+import com.citytechinc.cq.component.annotations.editconfig.ChildEditorConfig;
 import com.citytechinc.cq.component.annotations.editconfig.DropTarget;
 import com.citytechinc.cq.component.annotations.editconfig.FormParameter;
 
@@ -330,6 +331,15 @@ public @interface Component {
 	 * @return String
 	 */
 	String inPlaceEditingEditorType() default "";
+
+	/**
+	 * Specifies the configuration(s) for child in place editors. It only makes sense to include the child editor
+	 * configurations if the inPlaceEditingActive is set to 'true' and the inPlaceEditingEditorType is set to 'hybrid'.
+	 * For more information, see the <a href=
+	 * "https://docs.adobe.com/docs/en/aem/6-1/develop/components/multiple-inplace-editors.html"
+	 * >Configuring Multiple Editors Documentation</a>.
+	 */
+	ChildEditorConfig[] inPlaceEditingChildEditorConfigs() default {};
 
 	/**
 	 * Establishes the set of form parameters written to the cq:formParameters

--- a/cq-component-annotations/src/main/java/com/citytechinc/cq/component/annotations/editconfig/ChildEditorConfig.java
+++ b/cq-component-annotations/src/main/java/com/citytechinc/cq/component/annotations/editconfig/ChildEditorConfig.java
@@ -1,0 +1,44 @@
+/**
+ *    Copyright 2013 CITYTECH, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.citytechinc.cq.component.annotations.editconfig;
+
+public @interface ChildEditorConfig {
+
+	/**
+	 * Applicable to Touch-UI only
+	 * The title of the In Place Editor - the displayable name of the property.
+	 *
+	 * @return String
+	 */
+	String title() default "";
+
+	/**
+	 * Applicable to Touch-UI only
+	 *
+	 * Type of the In Place Editor: 'text' or 'image' values are supported.
+	 *
+	 * @return String
+	 */
+	String type() default "text";
+
+	/**
+	 * Applicable to Touch-UI only
+	 *
+	 * Property name to save in the JCR.
+	 *
+	 */
+	String propertyName() default "";
+}

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/editconfig/factory/EditConfigFactory.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/editconfig/factory/EditConfigFactory.java
@@ -100,11 +100,6 @@ public class EditConfigFactory {
 			editConfigChildren.add(ecfp);
 		}
 
-        EditConfigInPlaceEditingChildEditors ecipece = getInPlaceEditingChildEditorsForEditConfig(componentAnnotation);
-        if (ecipece != null) {
-            editConfigChildren.add(ecipece);
-        }
-
 		EditConfigDropTargets ecdt = getDropTargetsForEditConfig(componentAnnotation);
 		if (ecdt != null) {
 			editConfigChildren.add(ecdt);
@@ -187,6 +182,16 @@ public class EditConfigFactory {
 				parameters.setEditorType(componentAnnotation.inPlaceEditingEditorType());
 			}
 			parameters.setActive(componentAnnotation.inPlaceEditingActive());
+
+            //handle child editors as a contained element
+            List<XmlElement> inPlaceEditingChildElements = new ArrayList<XmlElement>();
+            final EditConfigInPlaceEditingChildEditors childEditors
+                    = getInPlaceEditingChildEditorsForEditConfig(componentAnnotation);
+            if (childEditors != null) {
+                inPlaceEditingChildElements.add(childEditors);
+                parameters.setContainedElements(inPlaceEditingChildElements);
+            }
+
 			return new EditConfigInPlaceEditing(parameters);
 		}
 		return null;
@@ -206,7 +211,8 @@ public class EditConfigFactory {
 				params.setTitle(childEditorConfig.title());
 				params.setType(childEditorConfig.type());
 				params.setPropertyName(childEditorConfig.propertyName());
-				childEditorConfigs.add(new EditConfigInPlaceEditingChildEditorConfig(params));
+
+                childEditorConfigs.add(new EditConfigInPlaceEditingChildEditorConfig(params));
 			}
 
 			EditConfigInPlaceEditingChildEditorsParameters parameters =

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/editconfig/factory/EditConfigFactory.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/editconfig/factory/EditConfigFactory.java
@@ -15,20 +15,11 @@
  */
 package com.citytechinc.cq.component.editconfig.factory;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import javassist.CtClass;
-
-import org.codehaus.plexus.util.StringUtils;
-
 import com.citytechinc.cq.component.annotations.Component;
 import com.citytechinc.cq.component.annotations.Listener;
 import com.citytechinc.cq.component.annotations.editconfig.ActionConfig;
 import com.citytechinc.cq.component.annotations.editconfig.ActionConfigProperty;
+import com.citytechinc.cq.component.annotations.editconfig.ChildEditorConfig;
 import com.citytechinc.cq.component.annotations.editconfig.DropTarget;
 import com.citytechinc.cq.component.annotations.editconfig.FormParameter;
 import com.citytechinc.cq.component.dialog.exception.InvalidComponentClassException;
@@ -45,10 +36,22 @@ import com.citytechinc.cq.component.editconfig.droptargets.EditConfigDropTargets
 import com.citytechinc.cq.component.editconfig.formparameters.EditConfigFormParameters;
 import com.citytechinc.cq.component.editconfig.formparameters.EditConfigFormParametersParameters;
 import com.citytechinc.cq.component.editconfig.inplaceediting.EditConfigInPlaceEditing;
+import com.citytechinc.cq.component.editconfig.inplaceediting.EditConfigInPlaceEditingChildEditorConfig;
+import com.citytechinc.cq.component.editconfig.inplaceediting.EditConfigInPlaceEditingChildEditorConfigParameters;
+import com.citytechinc.cq.component.editconfig.inplaceediting.EditConfigInPlaceEditingChildEditors;
+import com.citytechinc.cq.component.editconfig.inplaceediting.EditConfigInPlaceEditingChildEditorsParameters;
 import com.citytechinc.cq.component.editconfig.inplaceediting.EditConfigInPlaceEditingParameters;
 import com.citytechinc.cq.component.editconfig.listeners.EditConfigListeners;
 import com.citytechinc.cq.component.editconfig.listeners.EditConfigListenersParameters;
 import com.citytechinc.cq.component.xml.XmlElement;
+import javassist.CtClass;
+import org.codehaus.plexus.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class EditConfigFactory {
 	private static final String ACTION_CONFIG_FIELD_NAME = "actionConfig";
@@ -96,6 +99,11 @@ public class EditConfigFactory {
 		if (ecfp != null) {
 			editConfigChildren.add(ecfp);
 		}
+
+        EditConfigInPlaceEditingChildEditors ecipece = getInPlaceEditingChildEditorsForEditConfig(componentAnnotation);
+        if (ecipece != null) {
+            editConfigChildren.add(ecipece);
+        }
 
 		EditConfigDropTargets ecdt = getDropTargetsForEditConfig(componentAnnotation);
 		if (ecdt != null) {
@@ -180,6 +188,32 @@ public class EditConfigFactory {
 			}
 			parameters.setActive(componentAnnotation.inPlaceEditingActive());
 			return new EditConfigInPlaceEditing(parameters);
+		}
+		return null;
+	}
+
+	private static EditConfigInPlaceEditingChildEditors getInPlaceEditingChildEditorsForEditConfig(
+			Component componentAnnotation) {
+		if (componentAnnotation.inPlaceEditingChildEditorConfigs().length > 0) {
+
+			List<EditConfigInPlaceEditingChildEditorConfig> childEditorConfigs =
+					new ArrayList<EditConfigInPlaceEditingChildEditorConfig>();
+
+			for (ChildEditorConfig childEditorConfig : componentAnnotation.inPlaceEditingChildEditorConfigs()) {
+				EditConfigInPlaceEditingChildEditorConfigParameters params =
+						new EditConfigInPlaceEditingChildEditorConfigParameters();
+				params.setFieldName(childEditorConfig.propertyName());
+				params.setTitle(childEditorConfig.title());
+				params.setType(childEditorConfig.type());
+				params.setPropertyName(childEditorConfig.propertyName());
+				childEditorConfigs.add(new EditConfigInPlaceEditingChildEditorConfig(params));
+			}
+
+			EditConfigInPlaceEditingChildEditorsParameters parameters =
+					new EditConfigInPlaceEditingChildEditorsParameters();
+			parameters.setContainedElements(childEditorConfigs);
+
+			return new EditConfigInPlaceEditingChildEditors(parameters);
 		}
 		return null;
 	}

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/editconfig/inplaceediting/EditConfigInPlaceEditingChildEditorConfig.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/editconfig/inplaceediting/EditConfigInPlaceEditingChildEditorConfig.java
@@ -1,0 +1,38 @@
+/**
+ *    Copyright 2013 CITYTECH, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.citytechinc.cq.component.editconfig.inplaceediting;
+
+import com.citytechinc.cq.component.xml.AbstractXmlElement;
+
+public class EditConfigInPlaceEditingChildEditorConfig extends AbstractXmlElement {
+	private final String title;
+	private final String type;
+
+	public EditConfigInPlaceEditingChildEditorConfig(EditConfigInPlaceEditingChildEditorConfigParameters parameters) {
+		super(parameters);
+		title = parameters.getTitle();
+		type = parameters.getType();
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public String getType() {
+		return type;
+	}
+
+}

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/editconfig/inplaceediting/EditConfigInPlaceEditingChildEditorConfigParameters.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/editconfig/inplaceediting/EditConfigInPlaceEditingChildEditorConfigParameters.java
@@ -1,0 +1,59 @@
+/**
+ *    Copyright 2013 CITYTECH, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.citytechinc.cq.component.editconfig.inplaceediting;
+
+import com.citytechinc.cq.component.xml.DefaultXmlElementParameters;
+
+public class EditConfigInPlaceEditingChildEditorConfigParameters extends DefaultXmlElementParameters {
+	private String title;
+	private String type;
+	private String propertyName;
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+	public String getType() {
+		return type;
+	}
+
+	public void setType(String type) {
+		this.type = type;
+	}
+
+	public void setPropertyName(String propertyName) {
+		this.propertyName = propertyName;
+	}
+
+	@Override
+	public String getFieldName() {
+		return propertyName;
+	}
+
+	@Override
+	public String getPrimaryType() {
+		return "cq:ChildEditorConfig";
+	}
+
+	@Override
+	public void setPrimaryType(String primaryType) {
+		throw new UnsupportedOperationException("PrimaryType is Static for EditConfigInPlaceEditingChildEditorConfig");
+	}
+}

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/editconfig/inplaceediting/EditConfigInPlaceEditingChildEditors.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/editconfig/inplaceediting/EditConfigInPlaceEditingChildEditors.java
@@ -1,0 +1,26 @@
+/**
+ *    Copyright 2013 CITYTECH, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.citytechinc.cq.component.editconfig.inplaceediting;
+
+import com.citytechinc.cq.component.xml.AbstractXmlElement;
+
+public class EditConfigInPlaceEditingChildEditors extends AbstractXmlElement {
+
+	public EditConfigInPlaceEditingChildEditors(EditConfigInPlaceEditingChildEditorsParameters parameters) {
+		super(parameters);
+	}
+
+}

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/editconfig/inplaceediting/EditConfigInPlaceEditingChildEditorsParameters.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/editconfig/inplaceediting/EditConfigInPlaceEditingChildEditorsParameters.java
@@ -1,0 +1,51 @@
+/**
+ *    Copyright 2013 CITYTECH, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.citytechinc.cq.component.editconfig.inplaceediting;
+
+import com.citytechinc.cq.component.util.Constants;
+import com.citytechinc.cq.component.xml.DefaultXmlElementParameters;
+
+public class EditConfigInPlaceEditingChildEditorsParameters extends DefaultXmlElementParameters {
+	@Override
+	public String getNameSpace() {
+		return Constants.CQ_NS_URI;
+	}
+
+	@Override
+	public void setNameSpace(String nameSpace) {
+		throw new UnsupportedOperationException("nameSpace is Static for EditConfigInPlaceEditingChildEditors");
+	}
+
+	@Override
+	public String getFieldName() {
+		return "cq:childEditors";
+	}
+
+	@Override
+	public void setFieldName(String fieldName) {
+		throw new UnsupportedOperationException("fieldName is Static for EditConfigInPlaceEditingChildEditors");
+	}
+
+	@Override
+	public String getPrimaryType() {
+		return Constants.NT_UNSTRUCTURED;
+	}
+
+	@Override
+	public void setPrimaryType(String primaryType) {
+		throw new UnsupportedOperationException("PrimaryType is Static for EditConfigInPlaceEditingChildEditors");
+	}
+}


### PR DESCRIPTION
Added support for defining multiple in place editors in the _cq_editConfig.xml file. This feature is only applicable to the Touch UI.
This is how the generated XML looks like (the cq:childEditors element is new):
`
  <cq:inplaceEditing active="{Boolean}true" editorType="hybrid" jcr:primaryType="cq:InplaceEditingConfig">
    <cq:childEditors jcr:primaryType="nt:unstructured">
      <text1 jcr:primaryType="cq:ChildEditorConfig" title="Text 1" type="text"/>
      <text2 jcr:primaryType="cq:ChildEditorConfig" title="Text 2" type="text"/>
    </cq:childEditors>
  </cq:inplaceEditing>
`
