### PR TITLE
Add `defaultPasteMode` to RTE edit plugin

### DIFF
--- a/cq-component-annotations/src/main/java/com/citytechinc/cq/component/annotations/widgets/rte/Edit.java
+++ b/cq-component-annotations/src/main/java/com/citytechinc/cq/component/annotations/widgets/rte/Edit.java
@@ -30,4 +30,12 @@ public @interface Edit {
 
 	public boolean pasteWordhtml() default true;
 
+	/**
+	 * @see <a href="https://docs.adobe.com/docs/en/aem/6-2/administer/operations/page-authoring/rich-text-editor.html#Default%20Paste%20Mode">Default Paste Mode</a>
+	 *
+	 * Currently only supported in Classic UI
+	 *
+	 * Possible values are 'wordhtml' (default), 'plaintext' or 'browser'
+	 */
+	public String defaultPasteMode() default "wordhtml";
 }

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/dialog/richtexteditor/EditRtePlugin.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/dialog/richtexteditor/EditRtePlugin.java
@@ -1,0 +1,35 @@
+/**
+ *    Copyright 2013 CITYTECH, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.citytechinc.cq.component.dialog.richtexteditor;
+
+public class EditRtePlugin extends RtePlugin {
+
+	public static final String UNDO = "undo";
+
+	private final String defaultPasteMode;
+
+	public EditRtePlugin(EditRtePluginParameters parameters) {
+
+		super(parameters);
+
+		this.defaultPasteMode = parameters.getDefaultPasteMode();
+
+	}
+
+	public String getDefaultPasteMode() {
+		return defaultPasteMode;
+	}
+}

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/dialog/richtexteditor/EditRtePlugin.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/dialog/richtexteditor/EditRtePlugin.java
@@ -17,7 +17,7 @@ package com.citytechinc.cq.component.dialog.richtexteditor;
 
 public class EditRtePlugin extends RtePlugin {
 
-	public static final String UNDO = "undo";
+	public static final String EDIT = "edit";
 
 	private final String defaultPasteMode;
 

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/dialog/richtexteditor/EditRtePluginParameters.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/dialog/richtexteditor/EditRtePluginParameters.java
@@ -1,0 +1,39 @@
+/**
+ *    Copyright 2013 CITYTECH, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.citytechinc.cq.component.dialog.richtexteditor;
+
+public class EditRtePluginParameters extends RtePluginParameters {
+	public static final String EDIT = "edit";
+	private String defaultPasteMode;
+
+	public String getDefaultPasteMode() {
+		return defaultPasteMode;
+	}
+
+	public void setDefaultPasteMode(String defaultPasteMode) {
+		this.defaultPasteMode = defaultPasteMode;
+	}
+
+	@Override
+	public String getFieldName() {
+		return EDIT;
+	}
+
+	@Override
+	public void setFieldName(String fieldName) {
+		throw new UnsupportedOperationException("Field Name is static for EditRTEPlugin");
+	}
+}

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/dialog/richtexteditor/RichTextEditorMaker.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/dialog/richtexteditor/RichTextEditorMaker.java
@@ -300,6 +300,7 @@ public class RichTextEditorMaker extends AbstractWidgetMaker<RichTextEditorWidge
 		if (rteAnnotation.edit().length > 0) {
 			Edit[] editAnnotations = rteAnnotation.edit();
 			Edit editAnnotation = editAnnotations[0];
+			String defaultPasteMode = editAnnotation.defaultPasteMode();
 
 			List<String> editFeatures = new ArrayList<String>();
 
@@ -318,10 +319,10 @@ public class RichTextEditorMaker extends AbstractWidgetMaker<RichTextEditorWidge
 			if (editAnnotation.pasteWordhtml()) {
 				editFeatures.add("paste-wordhtml");
 			}
-			RtePluginParameters widgetParameters = new RtePluginParameters();
-			widgetParameters.setFieldName("edit");
+			EditRtePluginParameters widgetParameters = new EditRtePluginParameters();
+			widgetParameters.setDefaultPasteMode(defaultPasteMode);
 			widgetParameters.setFeatures(convertFeatures(editFeatures));
-			return new RtePlugin(widgetParameters);
+			return new EditRtePlugin(widgetParameters);
 		}
 
 		return null;


### PR DESCRIPTION
Added `defaultPasteMode` property to edit RTE plugin.

> A default paste mode is available to the author by using Crtl-V. This can be configured to be one of three values

Currently it only seems to be supported in Classic UI but I wouldn't be surprised if this is resolved in AEM 6.3. Documentation doesn't suggest anything.

See Adobe Docs: https://docs.adobe.com/docs/en/aem/6-2/administer/operations/page-authoring/rich-text-editor.html#Default%20Paste%20Mode