### PR TITLE
FixedColumnLayout and Tab layout fix

### DIFF
--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/factory/TouchUIDialogFactory.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/factory/TouchUIDialogFactory.java
@@ -20,6 +20,7 @@ import com.citytechinc.cq.component.touchuidialog.TouchUIDialog;
 import com.citytechinc.cq.component.touchuidialog.TouchUIDialogParameters;
 import com.citytechinc.cq.component.touchuidialog.exceptions.TouchUIDialogGenerationException;
 import com.citytechinc.cq.component.touchuidialog.layout.Layout;
+import com.citytechinc.cq.component.touchuidialog.layout.columns.fixedcolumns.FixedColumnsLayoutMaker;
 import com.citytechinc.cq.component.touchuidialog.layout.maker.LayoutMaker;
 import com.citytechinc.cq.component.touchuidialog.layout.maker.LayoutMakerParameters;
 import com.citytechinc.cq.component.touchuidialog.layout.maker.exceptions.LayoutMakerException;
@@ -69,7 +70,14 @@ public class TouchUIDialogFactory {
 			layoutMakerParameters.setClassLoader(classLoader);
 			layoutMakerParameters.setClassPool(classPool);
 			layoutMakerParameters.setWidgetRegistry(widgetRegistry);
-			LayoutMaker layoutMaker = new TabsLayoutMaker(layoutMakerParameters);
+
+            LayoutMaker layoutMaker;
+            if (componentAnnotation.tabs().length > 0) {
+                layoutMaker = new TabsLayoutMaker(layoutMakerParameters);
+            }
+            else {
+                layoutMaker = new FixedColumnsLayoutMaker(layoutMakerParameters);
+            }
 
 			// Delegate the rest of the production to the LayoutMaker
 			Layout layout = layoutMaker.make();

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/layout/columns/fixedcolumns/FixedColumnsLayoutMaker.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/layout/columns/fixedcolumns/FixedColumnsLayoutMaker.java
@@ -1,0 +1,117 @@
+/**
+ *    Copyright 2017 ICF Olson
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.citytechinc.cq.component.touchuidialog.layout.columns.fixedcolumns;
+
+import com.citytechinc.cq.component.annotations.Component;
+import com.citytechinc.cq.component.touchuidialog.TouchUIDialogElement;
+import com.citytechinc.cq.component.touchuidialog.container.items.Items;
+import com.citytechinc.cq.component.touchuidialog.container.items.ItemsParameters;
+import com.citytechinc.cq.component.touchuidialog.layout.Layout;
+import com.citytechinc.cq.component.touchuidialog.layout.columns.Column;
+import com.citytechinc.cq.component.touchuidialog.layout.columns.ColumnParameters;
+import com.citytechinc.cq.component.touchuidialog.layout.maker.AbstractLayoutMaker;
+import com.citytechinc.cq.component.touchuidialog.layout.maker.LayoutMakerParameters;
+import com.citytechinc.cq.component.touchuidialog.layout.maker.exceptions.LayoutMakerException;
+import com.citytechinc.cq.component.touchuidialog.util.TouchUIDialogUtil;
+import com.citytechinc.cq.component.touchuidialog.widget.factory.TouchUIWidgetFactory;
+import com.citytechinc.cq.component.touchuidialog.widget.maker.TouchUIWidgetMakerParameters;
+import com.citytechinc.cq.component.xml.XmlElement;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class FixedColumnsLayoutMaker extends AbstractLayoutMaker {
+
+    public FixedColumnsLayoutMaker(LayoutMakerParameters parameters) {
+        super(parameters);
+    }
+
+    @Override
+    public Layout make() throws LayoutMakerException {
+
+        Component componentAnnotation = null;
+        try {
+            componentAnnotation = (Component) parameters.getComponentClass().getAnnotation(Component.class);
+        } catch (ClassNotFoundException e) {
+            throw new LayoutMakerException("Class Not Found Exception encountered looking up Component annotation", e);
+        }
+
+        // Construct the FixedColumnsLayout Parameters
+        FixedColumnsLayoutParameters layoutParameters = new FixedColumnsLayoutParameters();
+
+        // Construct the appropriate Layout Element
+        FixedColumnsLayoutElementParameters fixedColumnsLayoutElementParameters = new FixedColumnsLayoutElementParameters();
+
+        // Add the Items to the layout element
+        List<XmlElement> containedElements;
+
+        FixedColumnsLayoutElement layoutElement = new FixedColumnsLayoutElement(fixedColumnsLayoutElementParameters);
+        layoutElement.setFieldName("layout");
+
+        // Add the Layout element ot the contained elements list
+        containedElements = new ArrayList<XmlElement>();
+        containedElements.add(layoutElement);
+        containedElements.add(makeItems());
+        layoutParameters.setContainedElements(containedElements);
+
+        layoutParameters.setFieldName("content");
+
+        return new FixedColumnsLayout(layoutParameters);
+    }
+
+    protected Items makeItems() throws LayoutMakerException {
+
+        ItemsParameters itemsParameters = new ItemsParameters();
+        itemsParameters.setFieldName("items");
+
+        Component componentAnnotation = null;
+        try {
+            componentAnnotation = (Component) parameters.getComponentClass().getAnnotation(Component.class);
+        } catch (ClassNotFoundException e) {
+            throw new LayoutMakerException("Class Not Found Exception encountered looking up Component annotation", e);
+        }
+
+        ColumnParameters columnParameters = new ColumnParameters();
+        columnParameters.setFieldName("column");
+
+        try {
+            // Populate the column content
+            List<TouchUIWidgetMakerParameters> widgetMakerParameters =
+                    TouchUIDialogUtil.getWidgetMakerParametersForComponentClass(parameters.getComponentClass(),
+                            parameters.getClassLoader(), parameters.getClassPool(), parameters.getWidgetRegistry());
+
+            for (TouchUIWidgetMakerParameters currentWidgetMakerParameters : widgetMakerParameters) {
+
+                TouchUIDialogElement currentElement = TouchUIWidgetFactory.make(currentWidgetMakerParameters, -1);
+                if (currentElement != null) {
+                    currentElement.setRanking(currentWidgetMakerParameters.getDialogFieldConfig().getRanking());
+                    columnParameters.addItem(currentElement);
+                }
+
+            }
+        } catch (Exception e) {
+            throw new LayoutMakerException("Exception encountered while constructing widgets for layout", e);
+        }
+
+        // Create and add the column section
+        List<XmlElement> containedElements = new ArrayList<XmlElement>();
+        containedElements.add(new Column(columnParameters));
+        itemsParameters.setContainedElements(containedElements);
+
+        return new Items(itemsParameters);
+    }
+
+}

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/layout/tabs/TabsLayoutMaker.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/layout/tabs/TabsLayoutMaker.java
@@ -64,10 +64,8 @@ public class TabsLayoutMaker extends AbstractLayoutMaker {
 
 		// Construct the appropriate Layout Element
 		TabsLayoutElementParameters tabsLayoutElementParameters = new TabsLayoutElementParameters();
+        tabsLayoutElementParameters.setType("nav");
 		TabsLayoutElement layoutElement = new TabsLayoutElement(tabsLayoutElementParameters);
-
-		// TODO: Some of the example tab layouts use a type of 'nav'. Determine
-		// what this does and if it is appropriate to set type here
 
 		// Add the Layout element and Items to the contained elements list
 		List<XmlElement> containedElements = new ArrayList<XmlElement>();
@@ -99,7 +97,6 @@ public class TabsLayoutMaker extends AbstractLayoutMaker {
 		// Determine the Tabs to create
 		List<SectionParameters> tabParametersList = new ArrayList<SectionParameters>();
 		List<ColumnParameters> tabContentParametersList = new ArrayList<ColumnParameters>();
-		if (componentAnnotation.tabs().length > 0) {
 			for (Tab currentTabAnnotation : componentAnnotation.tabs()) {
 				if (StringUtils.isNotEmpty(currentTabAnnotation.title())
 					&& StringUtils.isNotEmpty(currentTabAnnotation.touchUIPath())) {
@@ -148,29 +145,6 @@ public class TabsLayoutMaker extends AbstractLayoutMaker {
 					tabParametersList.add(null);
 				}
 			}
-		} else {
-			SectionParameters currentTabParameters = new SectionParameters();
-
-			currentTabParameters.setTitle(componentAnnotation.value());
-
-			// Determine the layout to use for the Tab
-			// TODO: This probably needs to allow for dynamic in tab layout at
-			// some point
-			LayoutElement currentTabLayoutElement =
-				new FixedColumnsLayoutElement(new FixedColumnsLayoutElementParameters());
-			currentTabParameters.setLayoutElement(currentTabLayoutElement);
-
-			// Based on the layout set up container parameters to match the tab
-			// parameters
-			// TODO: This probably needs to allow for dynamic in tab layout at
-			// some point
-			ColumnParameters tabContentParameters = new ColumnParameters();
-			tabContentParameters.setFieldName("column");
-
-			tabContentParametersList.add(tabContentParameters);
-			tabParametersList.add(currentTabParameters);
-		}
-
 		try {
 			// Populate the content for each tab
 			List<TouchUIWidgetMakerParameters> widgetMakerParameters =


### PR DESCRIPTION
When there are no tabs defined there is no need for TabsLayout, only FixedColumn layout is needed.
Fixed dialog issue that included FixedColumn layout inside TabLayout when there are no tabs defined.
Now only FixedColumn layout is used when there are no tabs defined.

TabLayout now has type "nav" which removes nasty no left margin gui bug in dialog.