### PR TITLE
Add TouchUI CoralUI 3 dialogs support

### DIFF
--- a/cq-component-annotations/src/main/java/com/citytechinc/cq/component/annotations/MultiFieldChildResource.java
+++ b/cq-component-annotations/src/main/java/com/citytechinc/cq/component/annotations/MultiFieldChildResource.java
@@ -1,0 +1,31 @@
+/**
+ *    Copyright 2017 ICF Olson
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.citytechinc.cq.component.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Used to flag a field that represents a child resource for the composite Multifield.
+ * Used for Touch UI Coral3 Only
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target({ ElementType.FIELD })
+public @interface MultiFieldChildResource {
+
+}

--- a/cq-component-annotations/src/main/java/com/citytechinc/cq/component/annotations/widgets/AutoComplete.java
+++ b/cq-component-annotations/src/main/java/com/citytechinc/cq/component/annotations/widgets/AutoComplete.java
@@ -15,12 +15,12 @@
  */
 package com.citytechinc.cq.component.annotations.widgets;
 
+import com.citytechinc.cq.component.annotations.Property;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
-import com.citytechinc.cq.component.annotations.Property;
 
 @Retention(RetentionPolicy.CLASS)
 @Target({ ElementType.FIELD, ElementType.METHOD })
@@ -36,4 +36,13 @@ public @interface AutoComplete {
 	String optionsResourceType() default "";
 
 	Property[] datasourceProperties() default {};
+
+	/**
+	 * Used for Touch UI Coral3 Only
+	 *
+	 * Indicates if the user is forced to select only from the available choices.
+	 *
+	 * @return boolean
+	 */
+	boolean forceSelection() default false;
 }

--- a/cq-component-annotations/src/main/java/com/citytechinc/cq/component/annotations/widgets/DateField.java
+++ b/cq-component-annotations/src/main/java/com/citytechinc/cq/component/annotations/widgets/DateField.java
@@ -73,6 +73,16 @@ public @interface DateField {
 	String storedFormat() default "YYYY-MM-DD[T]HH:mm:ss.000Z";
 
 	/**
+	 * For Touch-UI Coral3 only
+	 *
+	 * Similar to format but uses a different standard for specifying date
+	 * formats.
+	 *
+	 * @return String
+	 */
+	String valueFormat() default "YYYY-MM-DD[T]HH:mm:ss.000Z";
+
+	/**
 	 * For Touch-UI only
 	 *
 	 * Display format for the date selected

--- a/cq-component-annotations/src/main/java/com/citytechinc/cq/component/annotations/widgets/DateTime.java
+++ b/cq-component-annotations/src/main/java/com/citytechinc/cq/component/annotations/widgets/DateTime.java
@@ -41,6 +41,16 @@ public @interface DateTime {
 	String storedFormat() default "";
 
 	/**
+	 * For Touch-UI Coral3 only
+	 *
+	 * Similar to format but uses a different standard for specifying date
+	 * formats.
+	 *
+	 * @return String
+	 */
+	String valueFormat() default "YYYY-MM-DD[T]HH:mm:ss.000Z";
+
+	/**
 	 * For Touch-UI only
 	 *
 	 * Display format for the date selected

--- a/cq-component-annotations/src/main/java/com/citytechinc/cq/component/annotations/widgets/Html5SmartFile.java
+++ b/cq-component-annotations/src/main/java/com/citytechinc/cq/component/annotations/widgets/Html5SmartFile.java
@@ -235,4 +235,41 @@ public @interface Html5SmartFile {
 	 * @return String
 	 */
 	public String icon() default "";
+
+	/**
+	 * Used for Touch UI Coral3 Only
+	 *
+	 * Set true to upload the files asynchronously
+	 *
+	 * @return boolean
+	 */
+	public boolean async() default false;
+
+	/**
+	 * Used for Touch UI Coral3 Only
+	 *
+	 * Visually hide the text. It is RECOMMENDED that every button has a text for a11y purpose.
+	 * Use this property to hide it visually, while still making it available for a11y.
+	 *
+	 * @return boolean
+	 */
+	public boolean hideText() default false;
+
+	/**
+	 * Used for Touch UI Coral3 Only
+	 *
+	 * The size of the icon - XS, S, M, L
+	 *
+	 * @return String
+	 */
+	public String iconSize() default "S";
+
+	/**
+	 * Used for Touch UI Coral3 Only
+	 *
+	 * The size of the button - M, L
+	 *
+	 * @return String
+	 */
+	public String size() default "M";
 }

--- a/cq-component-annotations/src/main/java/com/citytechinc/cq/component/annotations/widgets/MultiField.java
+++ b/cq-component-annotations/src/main/java/com/citytechinc/cq/component/annotations/widgets/MultiField.java
@@ -52,4 +52,12 @@ public @interface MultiField {
 	 */
 	boolean orderable() default ORDERABLE_DEFAULT;
 
+	/**
+	 * Used for Touch UI Coral3 Only
+	 *
+	 * Set true to handle the form content value as composite.
+	 *
+	 * @return boolean
+	 */
+	boolean composite() default false;
 }

--- a/cq-component-annotations/src/main/java/com/citytechinc/cq/component/annotations/widgets/NumberField.java
+++ b/cq-component-annotations/src/main/java/com/citytechinc/cq/component/annotations/widgets/NumberField.java
@@ -101,4 +101,12 @@ public @interface NumberField {
 	 */
 	double step() default 1;
 
+	/**
+	 * Used for Coral 3 Touch UI Only
+	 *
+	 * The value of SlingPostServlet @TypeHint
+	 *
+	 * @return String
+	 */
+	String typeHint() default "";
 }

--- a/cq-component-annotations/src/main/java/com/citytechinc/cq/component/annotations/widgets/PathField.java
+++ b/cq-component-annotations/src/main/java/com/citytechinc/cq/component/annotations/widgets/PathField.java
@@ -36,6 +36,7 @@ public @interface PathField {
 	public static final String ROOT_PATH_DEFAULT = "/";
 	public static final String ROOT_TITLE_DEFAULT = "Websites";
 	public static final boolean SHOW_TITLE_IN_TREE_DEFAULT = true;
+	public static final String DEFAULT_FILTER_VALUE = "hierarchyNotFile";
 
 	/**
 	 * Used for Classic UI only
@@ -94,7 +95,7 @@ public @interface PathField {
 	boolean showTitleInTree() default SHOW_TITLE_IN_TREE_DEFAULT;
 
 	/**
-	 * Used for Touch UI only
+	 * Used for Coral 2 Touch UI only
 	 *
 	 * Javascript source code for an option loader callback function. Takes two
 	 * arguments: (path, callback). See the default option loader implementation
@@ -109,7 +110,7 @@ public @interface PathField {
 	String optionLoader() default "";
 
 	/**
-	 * Used for Touch UI only
+	 * Used for Coral 2 Touch UI only
 	 *
 	 * Javascript source code for callback function that gets an option value
 	 * object as parameter and should return a stringified value for this
@@ -120,7 +121,7 @@ public @interface PathField {
 	String optionValueReader() default "";
 
 	/**
-	 * Used for Touch UI only
+	 * Used for Coral 2 Touch UI only
 	 *
 	 * Javascript source code for callback function that gets an option value
 	 * object as parameter and should return a stringified title for this
@@ -130,4 +131,31 @@ public @interface PathField {
 	 */
 	String optionTitleReader() default "";
 
+	/**
+	 * Used for Coral 3 Touch UI only.
+	 *
+	 * Indicates if the user must only select from the list of given options. If it is not forced, the user can enter arbitrary value
+	 *
+	 * @return boolean
+	 */
+	boolean forceSelection() default false;
+
+	/**
+	 * Used for Coral 3 Touch UI only.
+	 *
+	 * The filter applied to suggestion and picker.
+	 *
+	 * The default value is hierarchyNotFile.
+	 *
+	 * <ul>
+	 *   Valid values are:
+	 *   <li>folder - Shows only nt:folder nodes</li>
+	 *   <li>hierarchy - Shows only nt:hierarchyNode nodes</li>
+	 *   <li>hierarchyNotFile - Shows only nt:hierarchyNode nodes that are not nt:file</li>
+	 *   <li>nosystem - Shows non-system nodes: !node.getName().startsWith("rep:") && !node.getName().equals("jcr:system")</li>
+	 * </ul>
+	 *
+	 * @return String
+	 */
+	String filter() default DEFAULT_FILTER_VALUE;
 }

--- a/cq-component-annotations/src/main/java/com/citytechinc/cq/component/touchuidialog/DefaultTouchUIDialogElementParameters.java
+++ b/cq-component-annotations/src/main/java/com/citytechinc/cq/component/touchuidialog/DefaultTouchUIDialogElementParameters.java
@@ -20,6 +20,7 @@ import com.citytechinc.cq.component.xml.DefaultXmlElementParameters;
 public class DefaultTouchUIDialogElementParameters extends DefaultXmlElementParameters implements TouchUIDialogElementParameters {
 
 	protected String resourceType;
+	protected String touchUIDialogType;
 
 	public String getResourceType() {
 		return resourceType;
@@ -29,4 +30,11 @@ public class DefaultTouchUIDialogElementParameters extends DefaultXmlElementPara
 		this.resourceType = resourceType;
 	}
 
+	public String getTouchUIDialogType() {
+		return touchUIDialogType;
+	}
+
+	public void setTouchUIDialogType(String touchUIDialogType) {
+		this.touchUIDialogType = touchUIDialogType;
+	}
 }

--- a/cq-component-annotations/src/main/java/com/citytechinc/cq/component/touchuidialog/TouchUIDialogElementParameters.java
+++ b/cq-component-annotations/src/main/java/com/citytechinc/cq/component/touchuidialog/TouchUIDialogElementParameters.java
@@ -23,4 +23,7 @@ public interface TouchUIDialogElementParameters extends XmlElementParameters {
 
     void setResourceType(String resourceType);
 
+	String getTouchUIDialogType();
+
+	void setTouchUIDialogType(String touchUIDialogType);
 }

--- a/cq-component-annotations/src/main/java/com/citytechinc/cq/component/touchuidialog/TouchUIDialogType.java
+++ b/cq-component-annotations/src/main/java/com/citytechinc/cq/component/touchuidialog/TouchUIDialogType.java
@@ -1,0 +1,36 @@
+/**
+ *    Copyright 2017 ICF Olson
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.citytechinc.cq.component.touchuidialog;
+
+public enum TouchUIDialogType {
+
+	CORAL2("coral2"),
+	CORAL3("coral3");
+
+	private String type;
+
+	TouchUIDialogType(String type) {
+		this.type = type;
+	}
+
+	public String getType() {
+		return type;
+	}
+
+	public boolean isOfType(String type) {
+		return this.type.equalsIgnoreCase(type);
+	}
+}

--- a/cq-component-annotations/src/main/java/com/citytechinc/cq/component/touchuidialog/layout/maker/LayoutMakerParameters.java
+++ b/cq-component-annotations/src/main/java/com/citytechinc/cq/component/touchuidialog/layout/maker/LayoutMakerParameters.java
@@ -26,6 +26,7 @@ public class LayoutMakerParameters {
 	private ClassLoader classLoader;
 	private ClassPool classPool;
 	private TouchUIWidgetRegistry widgetRegistry;
+	private String touchUIDialogType;
 
 	public CtClass getComponentClass() {
 		return componentClass;
@@ -57,5 +58,13 @@ public class LayoutMakerParameters {
 
 	public void setWidgetRegistry(TouchUIWidgetRegistry widgetRegistry) {
 		this.widgetRegistry = widgetRegistry;
+	}
+
+	public String getTouchUIDialogType() {
+		return touchUIDialogType;
+	}
+
+	public void setTouchUIDialogType(String touchUIDialogType) {
+		this.touchUIDialogType = touchUIDialogType;
 	}
 }

--- a/cq-component-annotations/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/maker/AbstractTouchUIWidgetMaker.java
+++ b/cq-component-annotations/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/maker/AbstractTouchUIWidgetMaker.java
@@ -15,16 +15,6 @@
  */
 package com.citytechinc.cq.component.touchuidialog.widget.maker;
 
-import java.lang.reflect.ParameterizedType;
-import java.util.HashMap;
-import java.util.Map;
-
-import javassist.CtClass;
-import javassist.CtField;
-import javassist.NotFoundException;
-
-import org.codehaus.plexus.util.StringUtils;
-
 import com.citytechinc.cq.component.annotations.Property;
 import com.citytechinc.cq.component.annotations.Property.RenderValue;
 import com.citytechinc.cq.component.dialog.exception.InvalidComponentFieldException;
@@ -32,6 +22,14 @@ import com.citytechinc.cq.component.touchuidialog.TouchUIDialogElement;
 import com.citytechinc.cq.component.touchuidialog.exceptions.TouchUIDialogGenerationException;
 import com.citytechinc.cq.component.touchuidialog.widget.TouchUIWidgetParameters;
 import com.citytechinc.cq.component.util.ComponentUtil;
+import javassist.CtClass;
+import javassist.CtField;
+import javassist.NotFoundException;
+import org.codehaus.plexus.util.StringUtils;
+
+import java.lang.reflect.ParameterizedType;
+import java.util.HashMap;
+import java.util.Map;
 
 public abstract class AbstractTouchUIWidgetMaker<T extends TouchUIWidgetParameters> implements TouchUIWidgetMaker {
 

--- a/cq-component-annotations/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/maker/TouchUIWidgetMakerParameters.java
+++ b/cq-component-annotations/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/maker/TouchUIWidgetMakerParameters.java
@@ -30,6 +30,7 @@ public class TouchUIWidgetMakerParameters {
 	private String resourceType;
 	private boolean useDotSlashInName;
 	private TouchUIWidgetRegistry widgetRegistry;
+	private String touchUIDialogType;
 
 	public DialogFieldConfig getDialogFieldConfig() {
 		return dialogFieldConfig;
@@ -93,5 +94,13 @@ public class TouchUIWidgetMakerParameters {
 
 	public void setWidgetRegistry(TouchUIWidgetRegistry widgetRegistry) {
 		this.widgetRegistry = widgetRegistry;
+	}
+
+	public String getTouchUIDialogType() {
+		return touchUIDialogType;
+	}
+
+	public void setTouchUIDialogType(String touchUIDialogType) {
+		this.touchUIDialogType = touchUIDialogType;
 	}
 }

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/maven/ComponentMojo.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/maven/ComponentMojo.java
@@ -15,19 +15,18 @@
  */
 package com.citytechinc.cq.component.maven;
 
-import java.io.File;
-import java.net.MalformedURLException;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
+import com.citytechinc.cq.component.annotations.Component;
+import com.citytechinc.cq.component.dialog.ComponentNameTransformer;
+import com.citytechinc.cq.component.dialog.widget.WidgetRegistry;
+import com.citytechinc.cq.component.dialog.widget.impl.DefaultWidgetRegistry;
+import com.citytechinc.cq.component.editconfig.registry.DefaultInPlaceEditorRegistry;
+import com.citytechinc.cq.component.editconfig.registry.InPlaceEditorRegistry;
+import com.citytechinc.cq.component.maven.util.ComponentMojoUtil;
+import com.citytechinc.cq.component.maven.util.LogSingleton;
+import com.citytechinc.cq.component.touchuidialog.widget.registry.DefaultTouchUIWidgetRegistry;
+import com.citytechinc.cq.component.touchuidialog.widget.registry.TouchUIWidgetRegistry;
 import javassist.ClassPool;
 import javassist.CtClass;
-
-import javax.naming.ConfigurationException;
-
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.plugin.AbstractMojo;
@@ -40,16 +39,10 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
 import org.reflections.Reflections;
 
-import com.citytechinc.cq.component.annotations.Component;
-import com.citytechinc.cq.component.dialog.ComponentNameTransformer;
-import com.citytechinc.cq.component.dialog.widget.WidgetRegistry;
-import com.citytechinc.cq.component.dialog.widget.impl.DefaultWidgetRegistry;
-import com.citytechinc.cq.component.editconfig.registry.DefaultInPlaceEditorRegistry;
-import com.citytechinc.cq.component.editconfig.registry.InPlaceEditorRegistry;
-import com.citytechinc.cq.component.maven.util.ComponentMojoUtil;
-import com.citytechinc.cq.component.maven.util.LogSingleton;
-import com.citytechinc.cq.component.touchuidialog.widget.registry.DefaultTouchUIWidgetRegistry;
-import com.citytechinc.cq.component.touchuidialog.widget.registry.TouchUIWidgetRegistry;
+import javax.naming.ConfigurationException;
+import java.io.File;
+import java.net.MalformedURLException;
+import java.util.*;
 
 @Mojo(name = "component", defaultPhase = LifecyclePhase.PACKAGE, requiresDependencyResolution = ResolutionScope.COMPILE)
 public class ComponentMojo extends AbstractMojo {
@@ -79,6 +72,9 @@ public class ComponentMojo extends AbstractMojo {
 
 	@Parameter(defaultValue = "true")
 	private boolean generateTouchUiDialogs;
+
+	@Parameter(defaultValue = "false")
+	private boolean useCoral3Dialogs;
 
 	@Parameter(defaultValue = "true")
 	private boolean generateClassicUiDialogs;
@@ -126,7 +122,7 @@ public class ComponentMojo extends AbstractMojo {
 			ComponentMojoUtil.buildArchiveFileForProjectAndClassList(classList, widgetRegistry, touchUIWidgetRegistry,
 				inPlaceEditorRegistry, classLoader, classPool, new File(project.getBuild().getDirectory()),
 				componentPathBase, componentPathSuffix, defaultComponentGroup, getArchiveFileForProject(),
-				getTempArchiveFileForProject(), transformer, generateTouchUiDialogs, generateClassicUiDialogs);
+				getTempArchiveFileForProject(), transformer, generateTouchUiDialogs, useCoral3Dialogs, generateClassicUiDialogs);
 
 		} catch (Exception e) {
 			getLog().error(e.getMessage(), e);

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/maven/util/ComponentMojoUtil.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/maven/util/ComponentMojoUtil.java
@@ -15,45 +15,6 @@
  */
 package com.citytechinc.cq.component.maven.util;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.InvocationTargetException;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.URLClassLoader;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import javassist.CannotCompileException;
-import javassist.ClassPool;
-import javassist.CtClass;
-import javassist.CtField;
-import javassist.CtMethod;
-import javassist.NotFoundException;
-
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.TransformerException;
-
-import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
-import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
-import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
-import org.apache.maven.project.MavenProject;
-import org.codehaus.plexus.util.StringUtils;
-import org.reflections.Reflections;
-import org.reflections.scanners.TypeAnnotationsScanner;
-import org.reflections.util.ClasspathHelper;
-import org.reflections.util.ConfigurationBuilder;
-
 import com.citytechinc.cq.classpool.ClassLoaderClassPool;
 import com.citytechinc.cq.component.annotations.Component;
 import com.citytechinc.cq.component.annotations.config.InPlaceEditor;
@@ -74,6 +35,7 @@ import com.citytechinc.cq.component.editconfig.maker.InPlaceEditorMaker;
 import com.citytechinc.cq.component.editconfig.registry.InPlaceEditorRegistry;
 import com.citytechinc.cq.component.editconfig.util.EditConfigUtil;
 import com.citytechinc.cq.component.touchuidialog.TouchUIDialogElement;
+import com.citytechinc.cq.component.touchuidialog.TouchUIDialogType;
 import com.citytechinc.cq.component.touchuidialog.exceptions.TouchUIDialogGenerationException;
 import com.citytechinc.cq.component.touchuidialog.exceptions.TouchUIDialogWriteException;
 import com.citytechinc.cq.component.touchuidialog.util.TouchUIDialogUtil;
@@ -84,6 +46,31 @@ import com.citytechinc.cq.component.util.TouchUIWidgetConfigHolder;
 import com.citytechinc.cq.component.util.WidgetConfigHolder;
 import com.citytechinc.cq.component.xml.AbstractXmlElement;
 import com.citytechinc.cq.component.xml.XmlWriter;
+import javassist.*;
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
+import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.StringUtils;
+import org.reflections.Reflections;
+import org.reflections.scanners.TypeAnnotationsScanner;
+import org.reflections.util.ClasspathHelper;
+import org.reflections.util.ConfigurationBuilder;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.TransformerException;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.*;
 
 public class ComponentMojoUtil {
 	private static final String OUTPUT_PATH = "tempComponentConfig";
@@ -196,7 +183,7 @@ public class ComponentMojoUtil {
 		TouchUIWidgetRegistry touchUIWidgetRegistry, InPlaceEditorRegistry inPlaceEditorRegistry,
 		ClassLoader classLoader, ClassPool classPool, File buildDirectory, String componentPathBase,
 		String defaultComponentPathSuffix, String defaultComponentGroup, File existingArchiveFile,
-		File tempArchiveFile, ComponentNameTransformer transformer, boolean generateTouchUiDialogs, boolean generateClassicUiDialogs)
+		File tempArchiveFile, ComponentNameTransformer transformer, boolean generateTouchUiDialogs, boolean useCoral3Dialogs, boolean generateClassicUiDialogs)
 		throws OutputFailureException, IOException, InvalidComponentClassException, InvalidComponentFieldException,
 		ParserConfigurationException, TransformerException, ClassNotFoundException, CannotCompileException,
 		NotFoundException, SecurityException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException,
@@ -255,9 +242,17 @@ public class ComponentMojoUtil {
 		}
 
 		if (generateTouchUiDialogs) {
+			String touchUIDialogType;
+
+			if(useCoral3Dialogs) {
+				touchUIDialogType = TouchUIDialogType.CORAL3.getType();
+			} else {
+				touchUIDialogType = TouchUIDialogType.CORAL2.getType();
+			}
+
 			TouchUIDialogUtil.buildDialogsFromClassList(classList, classLoader, classPool, touchUIWidgetRegistry,
-				transformer, buildDirectory, componentPathBase, defaultComponentPathSuffix, tempOutputStream,
-				existingArchiveEntryNames);
+					transformer, buildDirectory, componentPathBase, defaultComponentPathSuffix, tempOutputStream,
+					existingArchiveEntryNames, touchUIDialogType);
 		}
 
 		/*

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/container/Container.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/container/Container.java
@@ -20,6 +20,7 @@ import com.citytechinc.cq.component.touchuidialog.AbstractTouchUIDialogElement;
 public class Container extends AbstractTouchUIDialogElement {
 
 	public static final String RESOURCE_TYPE = "granite/ui/components/foundation/container";
+	public static final String RESOURCE_TYPE_CORAL3 = "granite/ui/components/coral/foundation/container";
 	public static final String PRIMARY_TYPE = "nt:unstructured";
 
 	public Container(ContainerParameters parameters) {

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/container/ContainerParameters.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/container/ContainerParameters.java
@@ -15,15 +15,16 @@
  */
 package com.citytechinc.cq.component.touchuidialog.container;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import com.citytechinc.cq.component.touchuidialog.TouchUIDialogElement;
 import com.citytechinc.cq.component.touchuidialog.DefaultTouchUIDialogElementParameters;
+import com.citytechinc.cq.component.touchuidialog.TouchUIDialogElement;
+import com.citytechinc.cq.component.touchuidialog.TouchUIDialogType;
 import com.citytechinc.cq.component.touchuidialog.container.items.Items;
 import com.citytechinc.cq.component.touchuidialog.container.items.ItemsParameters;
 import com.citytechinc.cq.component.touchuidialog.layout.LayoutElement;
 import com.citytechinc.cq.component.xml.XmlElement;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class ContainerParameters extends DefaultTouchUIDialogElementParameters {
 
@@ -37,6 +38,9 @@ public class ContainerParameters extends DefaultTouchUIDialogElementParameters {
 
 	@Override
 	public String getResourceType() {
+		if(TouchUIDialogType.CORAL3.isOfType(getTouchUIDialogType())) {
+			return Container.RESOURCE_TYPE_CORAL3;
+		}
 		return Container.RESOURCE_TYPE;
 	}
 

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/factory/TouchUIDialogFactory.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/factory/TouchUIDialogFactory.java
@@ -18,11 +18,14 @@ package com.citytechinc.cq.component.touchuidialog.factory;
 import com.citytechinc.cq.component.annotations.Component;
 import com.citytechinc.cq.component.touchuidialog.TouchUIDialog;
 import com.citytechinc.cq.component.touchuidialog.TouchUIDialogParameters;
+import com.citytechinc.cq.component.touchuidialog.TouchUIDialogType;
 import com.citytechinc.cq.component.touchuidialog.exceptions.TouchUIDialogGenerationException;
 import com.citytechinc.cq.component.touchuidialog.layout.Layout;
+import com.citytechinc.cq.component.touchuidialog.layout.columns.fixedcolumns.FixedColumnsLayoutCoral3Maker;
 import com.citytechinc.cq.component.touchuidialog.layout.maker.LayoutMaker;
 import com.citytechinc.cq.component.touchuidialog.layout.maker.LayoutMakerParameters;
 import com.citytechinc.cq.component.touchuidialog.layout.maker.exceptions.LayoutMakerException;
+import com.citytechinc.cq.component.touchuidialog.layout.tabs.TabsLayoutCoral3Maker;
 import com.citytechinc.cq.component.touchuidialog.layout.tabs.TabsLayoutMaker;
 import com.citytechinc.cq.component.touchuidialog.widget.registry.TouchUIWidgetRegistry;
 import com.citytechinc.cq.component.xml.XmlElement;
@@ -41,7 +44,7 @@ public class TouchUIDialogFactory {
 
 	@Nullable
 	public static TouchUIDialog make(CtClass componentClass, ClassLoader classLoader, ClassPool classPool,
-		TouchUIWidgetRegistry widgetRegistry) throws TouchUIDialogGenerationException {
+		TouchUIWidgetRegistry widgetRegistry, String touchUIDialogType) throws TouchUIDialogGenerationException {
 		try {
 
 			Component componentAnnotation = (Component) componentClass.getAnnotation(Component.class);
@@ -69,7 +72,19 @@ public class TouchUIDialogFactory {
 			layoutMakerParameters.setClassLoader(classLoader);
 			layoutMakerParameters.setClassPool(classPool);
 			layoutMakerParameters.setWidgetRegistry(widgetRegistry);
-			LayoutMaker layoutMaker = new TabsLayoutMaker(layoutMakerParameters);
+			layoutMakerParameters.setTouchUIDialogType(touchUIDialogType);
+
+			LayoutMaker layoutMaker;
+
+			if(TouchUIDialogType.CORAL3.isOfType(touchUIDialogType)) {
+				if (componentAnnotation.tabs().length > 0) {
+					layoutMaker = new TabsLayoutCoral3Maker(layoutMakerParameters);
+				} else {
+					layoutMaker = new FixedColumnsLayoutCoral3Maker(layoutMakerParameters);
+				}
+			} else {
+				layoutMaker = new TabsLayoutMaker(layoutMakerParameters);
+			}
 
 			// Delegate the rest of the production to the LayoutMaker
 			Layout layout = layoutMaker.make();
@@ -95,5 +110,4 @@ public class TouchUIDialogFactory {
 			throw new TouchUIDialogGenerationException("Layout Maker Exception encountered producing Dialog Layout", e);
 		}
 	}
-
 }

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/layout/columns/fixedcolumns/FixedColumnsLayoutCoral3Maker.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/layout/columns/fixedcolumns/FixedColumnsLayoutCoral3Maker.java
@@ -1,0 +1,98 @@
+/**
+ *    Copyright 2017 ICF Olson
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.citytechinc.cq.component.touchuidialog.layout.columns.fixedcolumns;
+
+import com.citytechinc.cq.component.touchuidialog.TouchUIDialogElement;
+import com.citytechinc.cq.component.touchuidialog.container.items.Items;
+import com.citytechinc.cq.component.touchuidialog.container.items.ItemsParameters;
+import com.citytechinc.cq.component.touchuidialog.layout.Layout;
+import com.citytechinc.cq.component.touchuidialog.layout.columns.Column;
+import com.citytechinc.cq.component.touchuidialog.layout.columns.ColumnParameters;
+import com.citytechinc.cq.component.touchuidialog.layout.maker.AbstractLayoutMaker;
+import com.citytechinc.cq.component.touchuidialog.layout.maker.LayoutMakerParameters;
+import com.citytechinc.cq.component.touchuidialog.layout.maker.exceptions.LayoutMakerException;
+import com.citytechinc.cq.component.touchuidialog.util.TouchUIDialogUtil;
+import com.citytechinc.cq.component.touchuidialog.widget.factory.TouchUIWidgetFactory;
+import com.citytechinc.cq.component.touchuidialog.widget.maker.TouchUIWidgetMakerParameters;
+
+import java.util.List;
+
+public class FixedColumnsLayoutCoral3Maker extends AbstractLayoutMaker {
+
+	public FixedColumnsLayoutCoral3Maker(LayoutMakerParameters parameters) {
+		super(parameters);
+	}
+
+	@Override
+	public Layout make() throws LayoutMakerException {
+		// Create layout element and add items to it
+		FixedColumnsLayoutElementParameters fixedColumnsLayoutElementParameters = new FixedColumnsLayoutElementParameters();
+		fixedColumnsLayoutElementParameters.setContainedElements(TouchUIDialogUtil.createContainedElements(makeItems()));
+		fixedColumnsLayoutElementParameters.setTouchUIDialogType(parameters.getTouchUIDialogType());
+		FixedColumnsLayoutElement layoutElement = new FixedColumnsLayoutElement(fixedColumnsLayoutElementParameters);
+		layoutElement.setFieldName("fixedColumns");
+
+		// Create items element and add layout element to it
+		ItemsParameters itemsParameters = new ItemsParameters();
+		itemsParameters.setFieldName("items");
+		itemsParameters.setContainedElements(TouchUIDialogUtil.createContainedElements(layoutElement));
+		Items items = new Items(itemsParameters);
+
+		// Create content element and add items element to it
+		FixedColumnsLayoutParameters layoutParameters = new FixedColumnsLayoutParameters();
+		layoutParameters.setContainedElements(TouchUIDialogUtil.createContainedElements(items));
+		layoutParameters.setTouchUIDialogType(parameters.getTouchUIDialogType());
+		layoutParameters.setFieldName("content");
+
+		return new FixedColumnsLayout(layoutParameters);
+	}
+
+	protected Items makeItems() throws LayoutMakerException {
+		ColumnParameters columnParameters = new ColumnParameters();
+		columnParameters.setTouchUIDialogType(parameters.getTouchUIDialogType());
+		columnParameters.setFieldName("column");
+
+		try {
+			// Populate the column content
+			List<TouchUIWidgetMakerParameters> widgetMakerParameters =
+					TouchUIDialogUtil.getWidgetMakerParametersForComponentClass(
+							parameters.getComponentClass(),
+							parameters.getClassLoader(),
+							parameters.getClassPool(),
+							parameters.getWidgetRegistry(),
+							parameters.getTouchUIDialogType());
+
+			for (TouchUIWidgetMakerParameters currentWidgetMakerParameters : widgetMakerParameters) {
+				currentWidgetMakerParameters.setTouchUIDialogType(parameters.getTouchUIDialogType());
+				TouchUIDialogElement currentElement = TouchUIWidgetFactory.make(currentWidgetMakerParameters, -1);
+				if (currentElement != null) {
+					currentElement.setRanking(currentWidgetMakerParameters.getDialogFieldConfig().getRanking());
+					columnParameters.addItem(currentElement);
+				}
+			}
+		} catch (Exception e) {
+			throw new LayoutMakerException("Exception encountered while constructing widgets for layout", e);
+		}
+
+		// Create and add the column section
+		Column column = new Column(columnParameters);
+		ItemsParameters itemsParameters = new ItemsParameters();
+		itemsParameters.setFieldName("items");
+		itemsParameters.setContainedElements(TouchUIDialogUtil.createContainedElements(column));
+
+		return new Items(itemsParameters);
+	}
+}

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/layout/columns/fixedcolumns/FixedColumnsLayoutElement.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/layout/columns/fixedcolumns/FixedColumnsLayoutElement.java
@@ -16,14 +16,63 @@
 package com.citytechinc.cq.component.touchuidialog.layout.columns.fixedcolumns;
 
 import com.citytechinc.cq.component.touchuidialog.layout.AbstractLayoutElement;
-import com.citytechinc.cq.component.touchuidialog.layout.LayoutElementParameters;
+import com.citytechinc.cq.component.util.Constants;
+import com.citytechinc.cq.component.xml.NameSpacedAttribute;
+import org.codehaus.plexus.util.StringUtils;
 
 public class FixedColumnsLayoutElement extends AbstractLayoutElement {
 
 	public static final String RESOURCE_TYPE = "granite/ui/components/foundation/layouts/fixedcolumns";
+	public static final String RESOURCE_TYPE_CORAL3 = "granite/ui/components/coral/foundation/fixedcolumns";
 
-	public FixedColumnsLayoutElement(LayoutElementParameters parameters) {
+	private NameSpacedAttribute<String> title;
+	private String path;
+	private final NameSpacedAttribute<Boolean> showOnCreate;
+	private final NameSpacedAttribute<Boolean> hideOnEdit;
+	private NameSpacedAttribute<String> orderBefore;
+
+	public FixedColumnsLayoutElement(FixedColumnsLayoutElementParameters parameters) {
 		super(parameters);
+
+		if (StringUtils.isNotEmpty(parameters.getTitle())) {
+			this.title =
+					new NameSpacedAttribute<String>(Constants.JCR_NS_URI, Constants.JCR_NS_PREFIX, parameters.getTitle());
+		}
+
+		if (StringUtils.isNotEmpty(parameters.getPath())) {
+			this.path = parameters.getPath();
+		}
+
+		showOnCreate =
+				new NameSpacedAttribute<Boolean>(Constants.CQ_NS_URI, Constants.CQ_NS_PREFIX, parameters.isShowOnCreate());
+
+		hideOnEdit =
+				new NameSpacedAttribute<Boolean>(Constants.CQ_NS_URI, Constants.CQ_NS_PREFIX, parameters.isHideOnEdit());
+
+		if (StringUtils.isNotEmpty(parameters.getOrderBefore())) {
+			orderBefore =
+					new NameSpacedAttribute<String>(Constants.SLING_NS_PREFIX, Constants.SLING_NS_PREFIX,
+							parameters.getOrderBefore());
+		}
 	}
 
+	public NameSpacedAttribute<String> getTitle() {
+		return title;
+	}
+
+	public String getPath() {
+		return path;
+	}
+
+	public NameSpacedAttribute<Boolean> getShowOnCreate() {
+		return showOnCreate;
+	}
+
+	public NameSpacedAttribute<Boolean> getHideOnEdit() {
+		return hideOnEdit;
+	}
+
+	public NameSpacedAttribute<String> getOrderBefore() {
+		return orderBefore;
+	}
 }

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/layout/columns/fixedcolumns/FixedColumnsLayoutElementParameters.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/layout/columns/fixedcolumns/FixedColumnsLayoutElementParameters.java
@@ -15,12 +15,28 @@
  */
 package com.citytechinc.cq.component.touchuidialog.layout.columns.fixedcolumns;
 
+import com.citytechinc.cq.component.touchuidialog.TouchUIDialogElement;
+import com.citytechinc.cq.component.touchuidialog.TouchUIDialogType;
+import com.citytechinc.cq.component.touchuidialog.container.Section;
 import com.citytechinc.cq.component.touchuidialog.layout.LayoutElementParameters;
+import org.codehaus.plexus.util.StringUtils;
 
 public class FixedColumnsLayoutElementParameters extends LayoutElementParameters {
 
+	private String title;
+	private String path;
+	private TouchUIDialogElement renderCondition;
+	private boolean showOnCreate;
+	private boolean hideOnEdit;
+	private String orderBefore;
+
 	@Override
 	public String getResourceType() {
+		if (StringUtils.isNotEmpty(path)) {
+			return Section.INCLUDE_RESOURCE_TYPE;
+		} else if(TouchUIDialogType.CORAL3.isOfType(getTouchUIDialogType())) {
+			return FixedColumnsLayoutElement.RESOURCE_TYPE_CORAL3;
+		}
 		return FixedColumnsLayoutElement.RESOURCE_TYPE;
 	}
 
@@ -29,4 +45,61 @@ public class FixedColumnsLayoutElementParameters extends LayoutElementParameters
 		throw new UnsupportedOperationException("resource type is Static for Tabs Layout Element");
 	}
 
+	@Override
+	public String getFieldName() {
+		return this.fieldName;
+	}
+
+	@Override
+	public void setFieldName(String fieldName) {
+		this.fieldName = fieldName;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+	public String getPath() {
+		return path;
+	}
+
+	public void setPath(String path) {
+		this.path = path;
+	}
+
+	public TouchUIDialogElement getRenderCondition() {
+		return renderCondition;
+	}
+
+	public void setRenderCondition(TouchUIDialogElement renderCondition) {
+		this.renderCondition = renderCondition;
+	}
+
+	public boolean isShowOnCreate() {
+		return showOnCreate;
+	}
+
+	public void setShowOnCreate(boolean showOnCreate) {
+		this.showOnCreate = showOnCreate;
+	}
+
+	public boolean isHideOnEdit() {
+		return hideOnEdit;
+	}
+
+	public void setHideOnEdit(boolean hideOnEdit) {
+		this.hideOnEdit = hideOnEdit;
+	}
+
+	public String getOrderBefore() {
+		return orderBefore;
+	}
+
+	public void setOrderBefore(String orderBefore) {
+		this.orderBefore = orderBefore;
+	}
 }

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/layout/tabs/TabsLayoutCoral3Maker.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/layout/tabs/TabsLayoutCoral3Maker.java
@@ -1,0 +1,196 @@
+/**
+ *    Copyright 2017 ICF Olson
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.citytechinc.cq.component.touchuidialog.layout.tabs;
+
+import com.citytechinc.cq.component.annotations.Component;
+import com.citytechinc.cq.component.annotations.Property;
+import com.citytechinc.cq.component.annotations.Tab;
+import com.citytechinc.cq.component.touchuidialog.*;
+import com.citytechinc.cq.component.touchuidialog.container.items.Items;
+import com.citytechinc.cq.component.touchuidialog.container.items.ItemsParameters;
+import com.citytechinc.cq.component.touchuidialog.layout.Layout;
+import com.citytechinc.cq.component.touchuidialog.layout.columns.Column;
+import com.citytechinc.cq.component.touchuidialog.layout.columns.ColumnParameters;
+import com.citytechinc.cq.component.touchuidialog.layout.columns.fixedcolumns.FixedColumnsLayoutElement;
+import com.citytechinc.cq.component.touchuidialog.layout.columns.fixedcolumns.FixedColumnsLayoutElementParameters;
+import com.citytechinc.cq.component.touchuidialog.layout.maker.AbstractLayoutMaker;
+import com.citytechinc.cq.component.touchuidialog.layout.maker.LayoutMakerParameters;
+import com.citytechinc.cq.component.touchuidialog.layout.maker.exceptions.LayoutMakerException;
+import com.citytechinc.cq.component.touchuidialog.util.TouchUIDialogUtil;
+import com.citytechinc.cq.component.touchuidialog.widget.factory.TouchUIWidgetFactory;
+import com.citytechinc.cq.component.touchuidialog.widget.maker.TouchUIWidgetMakerParameters;
+import com.citytechinc.cq.component.util.Constants;
+import com.google.common.collect.ImmutableMap;
+import org.codehaus.plexus.util.StringUtils;
+
+import java.util.*;
+
+public class TabsLayoutCoral3Maker extends AbstractLayoutMaker {
+
+	public TabsLayoutCoral3Maker(LayoutMakerParameters parameters) {
+		super(parameters);
+	}
+
+	@Override
+	public Layout make() throws LayoutMakerException {
+		// Create layout element and add items to it
+		TabsLayoutElementParameters tabsLayoutElementParameters = new TabsLayoutElementParameters();
+		tabsLayoutElementParameters.setContainedElements(TouchUIDialogUtil.createContainedElements(makeItems()));
+		tabsLayoutElementParameters.setTouchUIDialogType(parameters.getTouchUIDialogType());
+		tabsLayoutElementParameters.setAdditionalProperties(ImmutableMap.of("maximized", true));
+		TabsLayoutElement layoutElement = new TabsLayoutElement(tabsLayoutElementParameters);
+		layoutElement.setFieldName("tabs");
+
+		// Create items element and add layout element to it
+		ItemsParameters itemsParameters = new ItemsParameters();
+		itemsParameters.setFieldName("items");
+		itemsParameters.setContainedElements(TouchUIDialogUtil.createContainedElements(layoutElement));
+		Items items = new Items(itemsParameters);
+
+		// Create content element and add items element to it
+		TabsLayoutParameters layoutParameters = new TabsLayoutParameters();
+		layoutParameters.setContainedElements(TouchUIDialogUtil.createContainedElements(items));
+		layoutParameters.setTouchUIDialogType(parameters.getTouchUIDialogType());
+		layoutParameters.setFieldName("content");
+
+		return new TabsLayout(layoutParameters);
+	}
+
+	protected Items makeItems() throws LayoutMakerException {
+		Component componentAnnotation = null;
+		try {
+			componentAnnotation = (Component) parameters.getComponentClass().getAnnotation(Component.class);
+		} catch (ClassNotFoundException e) {
+			throw new LayoutMakerException("Class Not Found Exception encountered looking up Component annotation", e);
+		}
+
+		// Determine the Tabs to create
+		List<FixedColumnsLayoutElementParameters> tabParametersList = new ArrayList<FixedColumnsLayoutElementParameters>();
+		List<ColumnParameters> tabContentParametersList = new ArrayList<ColumnParameters>();
+
+		for (Tab currentTabAnnotation : componentAnnotation.tabs()) {
+			if (StringUtils.isNotEmpty(currentTabAnnotation.title())
+				&& StringUtils.isNotEmpty(currentTabAnnotation.touchUIPath())) {
+				throw new LayoutMakerException("Tabs can have only a path or a title");
+			}
+
+			if (StringUtils.isNotEmpty(currentTabAnnotation.title())
+				|| StringUtils.isNotEmpty(currentTabAnnotation.touchUIPath())) {
+				FixedColumnsLayoutElementParameters currentTabParameters = new FixedColumnsLayoutElementParameters();
+
+				if (StringUtils.isNotEmpty(currentTabAnnotation.title())) {
+					String fieldName = StringUtils.isNotBlank(currentTabAnnotation.touchUINodeName()) ? currentTabAnnotation.touchUINodeName() : currentTabAnnotation.title();
+					currentTabParameters.setFieldName(fieldName);
+					currentTabParameters.setTitle(currentTabAnnotation.title());
+					ColumnParameters tabContentParameters = new ColumnParameters();
+					tabContentParameters.setFieldName("column");
+					tabContentParameters.setTouchUIDialogType(parameters.getTouchUIDialogType());
+					tabContentParametersList.add(tabContentParameters);
+				} else {
+					String path = currentTabAnnotation.touchUIPath();
+					currentTabParameters.setFieldName(StringUtils.substring(path, StringUtils.lastIndexOfAny(path, new String[]{"/"})+1));
+					currentTabParameters.setPath(path);
+					tabContentParametersList.add(null);
+				}
+
+				if (StringUtils.isNotEmpty(currentTabAnnotation.renderConditionResourceType())) {
+					TouchUIDialogElementParameters renderParameters = new DefaultTouchUIDialogElementParameters();
+					renderParameters.setFieldName("rendercondition");
+					renderParameters.setPrimaryType(Constants.NT_UNSTRUCTURED);
+					renderParameters.setResourceType(currentTabAnnotation.renderConditionResourceType());
+					Map<String, String> additionalPropertiesMap = new HashMap<String, String>();
+					for (Property property : currentTabAnnotation.renderConditionProperties()) {
+						additionalPropertiesMap.put(property.name(), property.value());
+					}
+					renderParameters.setAdditionalProperties(additionalPropertiesMap);
+					DefaultTouchUIDialogElement renderConditionElement =
+						new DefaultTouchUIDialogElement(renderParameters);
+					currentTabParameters.setRenderCondition(renderConditionElement);
+				}
+				currentTabParameters.setShowOnCreate(currentTabAnnotation.showOnCreate());
+				currentTabParameters.setHideOnEdit(currentTabAnnotation.hideOnEdit());
+				if (StringUtils.isNotEmpty(currentTabAnnotation.orderBefore())) {
+					currentTabParameters.setOrderBefore(currentTabAnnotation.orderBefore());
+				}
+				currentTabParameters.setTouchUIDialogType(parameters.getTouchUIDialogType());
+				tabParametersList.add(currentTabParameters);
+			} else {
+				tabContentParametersList.add(null);
+				tabParametersList.add(null);
+			}
+		}
+
+		try {
+			// Populate the content for each tab
+			List<TouchUIWidgetMakerParameters> widgetMakerParameters =
+				TouchUIDialogUtil.getWidgetMakerParametersForComponentClass(
+						parameters.getComponentClass(),
+						parameters.getClassLoader(),
+						parameters.getClassPool(),
+						parameters.getWidgetRegistry(),
+						parameters.getTouchUIDialogType());
+
+			for (TouchUIWidgetMakerParameters currentWidgetMakerParameters : widgetMakerParameters) {
+				TouchUIDialogElement currentElement = TouchUIWidgetFactory.make(currentWidgetMakerParameters, -1);
+				if (currentElement != null) {
+					currentElement.setRanking(currentWidgetMakerParameters.getDialogFieldConfig().getRanking());
+
+					if (currentWidgetMakerParameters.getDialogFieldConfig().getTab() <= tabParametersList.size()) {
+						tabContentParametersList.get(currentWidgetMakerParameters.getDialogFieldConfig().getTab() - 1)
+							.addItem(currentElement);
+					} else {
+						throw new LayoutMakerException("Field "
+							+ currentWidgetMakerParameters.getDialogFieldConfig().getName() + " of class "
+							+ currentWidgetMakerParameters.getClass().getName() + " placed in non-existant tab "
+							+ currentWidgetMakerParameters.getDialogFieldConfig().getTab());
+					}
+				}
+			}
+		} catch (Exception e) {
+			throw new LayoutMakerException("Exception encountered while constructing widgets for layout", e);
+		}
+
+		// Add content to all tabs
+		for (int i = 0; i < tabParametersList.size(); i++) {
+			if (tabContentParametersList.get(i) != null) {
+				Collections.sort(tabContentParametersList.get(i).getItems(), new TouchUIDialogElementComparator());
+
+				Column column = new Column(tabContentParametersList.get(i));
+
+				ItemsParameters itemsParameters = new ItemsParameters();
+				itemsParameters.setFieldName("items");
+				itemsParameters.setContainedElements(TouchUIDialogUtil.createContainedElements(column));
+				Items items = new Items(itemsParameters);
+
+				tabParametersList.get(i).setContainedElements(TouchUIDialogUtil.createContainedElements(items));
+			}
+		}
+
+		// Create all Tabs
+		List<FixedColumnsLayoutElement> tabs = new ArrayList<FixedColumnsLayoutElement>();
+		for (FixedColumnsLayoutElementParameters currentLayoutElementParams : tabParametersList) {
+			if (currentLayoutElementParams != null) {
+				tabs.add(new FixedColumnsLayoutElement(currentLayoutElementParams));
+			}
+		}
+
+		ItemsParameters itemsParameters = new ItemsParameters();
+		itemsParameters.setFieldName("items");
+		itemsParameters.setContainedElements(tabs);
+
+		return new Items(itemsParameters);
+	}
+}

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/layout/tabs/TabsLayoutElement.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/layout/tabs/TabsLayoutElement.java
@@ -20,6 +20,7 @@ import com.citytechinc.cq.component.touchuidialog.layout.AbstractLayoutElement;
 public class TabsLayoutElement extends AbstractLayoutElement {
 
 	public static final String RESOURCE_TYPE = "granite/ui/components/foundation/layouts/tabs";
+	public static final String RESOURCE_TYPE_CORAL3 = "granite/ui/components/coral/foundation/tabs";
 
 	private String type;
 

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/layout/tabs/TabsLayoutElementParameters.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/layout/tabs/TabsLayoutElementParameters.java
@@ -15,6 +15,7 @@
  */
 package com.citytechinc.cq.component.touchuidialog.layout.tabs;
 
+import com.citytechinc.cq.component.touchuidialog.TouchUIDialogType;
 import com.citytechinc.cq.component.touchuidialog.layout.LayoutElementParameters;
 
 public class TabsLayoutElementParameters extends LayoutElementParameters {
@@ -31,6 +32,9 @@ public class TabsLayoutElementParameters extends LayoutElementParameters {
 
 	@Override
 	public String getResourceType() {
+		if(TouchUIDialogType.CORAL3.isOfType(getTouchUIDialogType())) {
+			return TabsLayoutElement.RESOURCE_TYPE_CORAL3;
+		}
 		return TabsLayoutElement.RESOURCE_TYPE;
 	}
 

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/layout/tabs/TabsLayoutMaker.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/layout/tabs/TabsLayoutMaker.java
@@ -15,22 +15,10 @@
  */
 package com.citytechinc.cq.component.touchuidialog.layout.tabs;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import org.codehaus.plexus.util.StringUtils;
-
 import com.citytechinc.cq.component.annotations.Component;
 import com.citytechinc.cq.component.annotations.Property;
 import com.citytechinc.cq.component.annotations.Tab;
-import com.citytechinc.cq.component.touchuidialog.DefaultTouchUIDialogElement;
-import com.citytechinc.cq.component.touchuidialog.DefaultTouchUIDialogElementParameters;
-import com.citytechinc.cq.component.touchuidialog.TouchUIDialogElement;
-import com.citytechinc.cq.component.touchuidialog.TouchUIDialogElementComparator;
-import com.citytechinc.cq.component.touchuidialog.TouchUIDialogElementParameters;
+import com.citytechinc.cq.component.touchuidialog.*;
 import com.citytechinc.cq.component.touchuidialog.container.Section;
 import com.citytechinc.cq.component.touchuidialog.container.SectionParameters;
 import com.citytechinc.cq.component.touchuidialog.container.items.Items;
@@ -49,6 +37,9 @@ import com.citytechinc.cq.component.touchuidialog.widget.factory.TouchUIWidgetFa
 import com.citytechinc.cq.component.touchuidialog.widget.maker.TouchUIWidgetMakerParameters;
 import com.citytechinc.cq.component.util.Constants;
 import com.citytechinc.cq.component.xml.XmlElement;
+import org.codehaus.plexus.util.StringUtils;
+
+import java.util.*;
 
 public class TabsLayoutMaker extends AbstractLayoutMaker {
 
@@ -175,7 +166,7 @@ public class TabsLayoutMaker extends AbstractLayoutMaker {
 			// Populate the content for each tab
 			List<TouchUIWidgetMakerParameters> widgetMakerParameters =
 				TouchUIDialogUtil.getWidgetMakerParametersForComponentClass(parameters.getComponentClass(),
-					parameters.getClassLoader(), parameters.getClassPool(), parameters.getWidgetRegistry());
+					parameters.getClassLoader(), parameters.getClassPool(), parameters.getWidgetRegistry(), parameters.getTouchUIDialogType());
 
 			for (TouchUIWidgetMakerParameters currentWidgetMakerParameters : widgetMakerParameters) {
 

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/util/TouchUIDialogUtil.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/util/TouchUIDialogUtil.java
@@ -15,20 +15,6 @@
  */
 package com.citytechinc.cq.component.touchuidialog.util;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-
-import javassist.ClassPool;
-import javassist.CtClass;
-import javassist.CtMember;
-import javassist.CtMethod;
-import javassist.NotFoundException;
-
-import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
-import org.codehaus.plexus.util.StringUtils;
-
 import com.citytechinc.cq.component.annotations.Component;
 import com.citytechinc.cq.component.annotations.DialogField;
 import com.citytechinc.cq.component.annotations.IgnoreDialogField;
@@ -47,6 +33,15 @@ import com.citytechinc.cq.component.touchuidialog.widget.maker.TouchUIWidgetMake
 import com.citytechinc.cq.component.touchuidialog.widget.radiogroup.RadioGroupWidget;
 import com.citytechinc.cq.component.touchuidialog.widget.registry.TouchUIWidgetRegistry;
 import com.citytechinc.cq.component.touchuidialog.widget.selection.options.OptionParameters;
+import com.citytechinc.cq.component.xml.XmlElement;
+import javassist.*;
+import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
+import org.codehaus.plexus.util.StringUtils;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 
 public class TouchUIDialogUtil {
 	private static final String OPTION_FIELD_NAME_PREFIX = "option";
@@ -57,14 +52,14 @@ public class TouchUIDialogUtil {
 	public static List<TouchUIDialog> buildDialogsFromClassList(List<CtClass> classList, ClassLoader classLoader,
 		ClassPool classPool, TouchUIWidgetRegistry widgetRegistry, ComponentNameTransformer transformer,
 		File buildDirectory, String componentPathBase, String defaultComponentPathSuffix,
-		ZipArchiveOutputStream archiveStream, Set<String> reservedNames) throws TouchUIDialogGenerationException,
+		ZipArchiveOutputStream archiveStream, Set<String> reservedNames, String touchUIDialogType) throws TouchUIDialogGenerationException,
 		TouchUIDialogWriteException, ClassNotFoundException, NotFoundException, InvalidComponentClassException {
 
 		List<TouchUIDialog> dialogList = new ArrayList<TouchUIDialog>();
 
 		for (CtClass currentComponentClass : classList) {
 			TouchUIDialog currentDialog =
-				TouchUIDialogFactory.make(currentComponentClass, classLoader, classPool, widgetRegistry);
+				TouchUIDialogFactory.make(currentComponentClass, classLoader, classPool, widgetRegistry, touchUIDialogType);
 
 			if (currentDialog != null && isWidgetInComponentClass(currentComponentClass)) {
 				File currentDialogOutput =
@@ -104,7 +99,7 @@ public class TouchUIDialogUtil {
 	}
 
 	public static List<TouchUIWidgetMakerParameters> getWidgetMakerParametersForComponentClass(CtClass componentClass,
-		ClassLoader classLoader, ClassPool classPool, TouchUIWidgetRegistry widgetRegistry) throws NotFoundException,
+		ClassLoader classLoader, ClassPool classPool, TouchUIWidgetRegistry widgetRegistry, String touchUIDialogType) throws NotFoundException,
 		ClassNotFoundException, InvalidComponentClassException {
 
 		List<TouchUIWidgetMakerParameters> widgetMakerParametersList = new ArrayList<TouchUIWidgetMakerParameters>();
@@ -141,6 +136,7 @@ public class TouchUIDialogUtil {
 					touchUIWidgetMakerParameters.setClassPool(classPool);
 					touchUIWidgetMakerParameters.setUseDotSlashInName(true);
 					touchUIWidgetMakerParameters.setWidgetRegistry(widgetRegistry);
+					touchUIWidgetMakerParameters.setTouchUIDialogType(touchUIDialogType);
 					widgetMakerParametersList.add(touchUIWidgetMakerParameters);
 				}
 			}
@@ -271,4 +267,13 @@ public class TouchUIDialogUtil {
 
 	}
 
+	public static List<XmlElement> createContainedElements(XmlElement ... elements) {
+		List<XmlElement> containedElements = new ArrayList<XmlElement>();
+
+		for(XmlElement element : elements) {
+			containedElements.add(element);
+		}
+
+		return containedElements;
+	}
 }

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/autocomplete/AutoCompleteCoral3Widget.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/autocomplete/AutoCompleteCoral3Widget.java
@@ -1,0 +1,51 @@
+/**
+ *    Copyright 2017 ICF Olson
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.citytechinc.cq.component.touchuidialog.widget.autocomplete;
+
+import com.citytechinc.cq.component.annotations.config.TouchUIWidget;
+import com.citytechinc.cq.component.annotations.widgets.AutoComplete;
+import com.citytechinc.cq.component.touchuidialog.widget.AbstractTouchUIWidget;
+
+@TouchUIWidget(annotationClass = AutoComplete.class, makerClass = AutoCompleteWidgetMaker.class,
+	resourceType = AutoCompleteCoral3Widget.RESOURCE_TYPE)
+public class AutoCompleteCoral3Widget extends AbstractTouchUIWidget {
+
+	public static final String RESOURCE_TYPE = "granite/ui/components/coral/foundation/form/autocomplete";
+
+	protected final boolean multiple;
+	protected final String mode;
+	protected final boolean forceSelection;
+
+	public AutoCompleteCoral3Widget(AutoCompleteWidgetParameters parameters) {
+		super(parameters);
+
+		multiple = parameters.isMultiple();
+		mode = parameters.getMode();
+		forceSelection = parameters.isForceSelection();
+	}
+
+	public boolean isMultiple() {
+		return multiple;
+	}
+
+	public String getMode() {
+		return mode;
+	}
+
+	public boolean isForceSelection(){
+		return forceSelection;
+	}
+}

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/autocomplete/AutoCompleteWidgetMaker.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/autocomplete/AutoCompleteWidgetMaker.java
@@ -15,17 +15,13 @@
  */
 package com.citytechinc.cq.component.touchuidialog.widget.autocomplete;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import org.codehaus.plexus.util.StringUtils;
-
 import com.citytechinc.cq.component.annotations.Property;
 import com.citytechinc.cq.component.annotations.widgets.AutoComplete;
 import com.citytechinc.cq.component.dialog.exception.InvalidComponentFieldException;
 import com.citytechinc.cq.component.touchuidialog.DefaultTouchUIDialogElementParameters;
 import com.citytechinc.cq.component.touchuidialog.TouchUIDialogElement;
 import com.citytechinc.cq.component.touchuidialog.TouchUIDialogElementParameters;
+import com.citytechinc.cq.component.touchuidialog.TouchUIDialogType;
 import com.citytechinc.cq.component.touchuidialog.exceptions.TouchUIDialogGenerationException;
 import com.citytechinc.cq.component.touchuidialog.widget.autocomplete.options.AutoCompleteOptions;
 import com.citytechinc.cq.component.touchuidialog.widget.autocomplete.values.AutoCompleteValues;
@@ -33,6 +29,10 @@ import com.citytechinc.cq.component.touchuidialog.widget.datasource.DataSource;
 import com.citytechinc.cq.component.touchuidialog.widget.datasource.DataSourceParameters;
 import com.citytechinc.cq.component.touchuidialog.widget.maker.AbstractTouchUIWidgetMaker;
 import com.citytechinc.cq.component.touchuidialog.widget.maker.TouchUIWidgetMakerParameters;
+import org.codehaus.plexus.util.StringUtils;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class AutoCompleteWidgetMaker extends AbstractTouchUIWidgetMaker<AutoCompleteWidgetParameters> {
 
@@ -54,7 +54,12 @@ public class AutoCompleteWidgetMaker extends AbstractTouchUIWidgetMaker<AutoComp
 		widgetParameters.setDatasource(makeDataSource());
 		widgetParameters.setOptions(makeOptions());
 		widgetParameters.setValues(makeValues());
+		widgetParameters.setForceSelection(isForceSelection());
+		widgetParameters.setTouchUIDialogType(parameters.getTouchUIDialogType());
 
+		if(TouchUIDialogType.CORAL3.isOfType(widgetParameters.getTouchUIDialogType())) {
+			return new AutoCompleteCoral3Widget(widgetParameters);
+		}
 		return new AutoCompleteWidget(widgetParameters);
 	}
 
@@ -110,5 +115,12 @@ public class AutoCompleteWidgetMaker extends AbstractTouchUIWidgetMaker<AutoComp
 			return fieldAnnotation.mode();
 		}
 		return null;
+	}
+
+	protected boolean isForceSelection() {
+		if(fieldAnnotation != null) {
+			return fieldAnnotation.forceSelection();
+		}
+		return false;
 	}
 }

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/autocomplete/AutoCompleteWidgetParameters.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/autocomplete/AutoCompleteWidgetParameters.java
@@ -15,12 +15,13 @@
  */
 package com.citytechinc.cq.component.touchuidialog.widget.autocomplete;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import com.citytechinc.cq.component.touchuidialog.TouchUIDialogElement;
+import com.citytechinc.cq.component.touchuidialog.TouchUIDialogType;
 import com.citytechinc.cq.component.touchuidialog.widget.DefaultTouchUIWidgetParameters;
 import com.citytechinc.cq.component.xml.XmlElement;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class AutoCompleteWidgetParameters extends DefaultTouchUIWidgetParameters {
 
@@ -29,6 +30,7 @@ public class AutoCompleteWidgetParameters extends DefaultTouchUIWidgetParameters
 	private TouchUIDialogElement datasource;
 	private TouchUIDialogElement values;
 	private TouchUIDialogElement options;
+	private boolean forceSelection;
 
 	// TODO: Look into the translateOptions mechanism
 
@@ -72,6 +74,14 @@ public class AutoCompleteWidgetParameters extends DefaultTouchUIWidgetParameters
 		this.options = options;
 	}
 
+	public boolean isForceSelection() {
+		return forceSelection;
+	}
+
+	public void setForceSelection(boolean forceSelection) {
+		this.forceSelection = forceSelection;
+	}
+
 	@Override
 	public List<? extends XmlElement> getContainedElements() {
 		List<XmlElement> allContainedElements = new ArrayList<XmlElement>();
@@ -95,6 +105,9 @@ public class AutoCompleteWidgetParameters extends DefaultTouchUIWidgetParameters
 
 	@Override
 	public String getResourceType() {
+		if(TouchUIDialogType.CORAL3.isOfType(getTouchUIDialogType())) {
+			return AutoCompleteCoral3Widget.RESOURCE_TYPE;
+		}
 		return AutoCompleteWidget.RESOURCE_TYPE;
 	}
 
@@ -102,5 +115,4 @@ public class AutoCompleteWidgetParameters extends DefaultTouchUIWidgetParameters
 	public void setResourceType(String resourceType) {
 		throw new UnsupportedOperationException("resourceType is Static for AutoCompleteWidget");
 	}
-
 }

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/checkbox/CheckboxCoral3Widget.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/checkbox/CheckboxCoral3Widget.java
@@ -1,0 +1,56 @@
+/**
+ *    Copyright 2017 ICF Olson
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.citytechinc.cq.component.touchuidialog.widget.checkbox;
+
+import com.citytechinc.cq.component.annotations.config.TouchUIWidget;
+import com.citytechinc.cq.component.annotations.widgets.CheckBox;
+import com.citytechinc.cq.component.touchuidialog.widget.AbstractTouchUIWidget;
+
+@TouchUIWidget(annotationClass = CheckBox.class, makerClass = CheckboxWidgetMaker.class,
+	resourceType = CheckboxCoral3Widget.RESOURCE_TYPE)
+public class CheckboxCoral3Widget extends AbstractTouchUIWidget {
+
+	public static final String RESOURCE_TYPE = "granite/ui/components/coral/foundation/form/checkbox";
+
+	private final String text;
+	private final String title;
+	private final boolean[] checked;
+
+	public CheckboxCoral3Widget(CheckboxWidgetParameters parameters) {
+		super(parameters);
+
+		text = parameters.getText();
+		title = parameters.getTitle();
+		checked = parameters.getChecked();
+
+	}
+
+	public String getText() {
+		return text;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public Boolean getChecked() {
+		if (checked != null && checked.length != 0) {
+			return new Boolean(checked[0]);
+		} else {
+			return null;
+		}
+	}
+}

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/checkbox/CheckboxWidgetMaker.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/checkbox/CheckboxWidgetMaker.java
@@ -15,6 +15,7 @@
  */
 package com.citytechinc.cq.component.touchuidialog.widget.checkbox;
 
+import com.citytechinc.cq.component.touchuidialog.TouchUIDialogType;
 import org.codehaus.plexus.util.StringUtils;
 
 import com.citytechinc.cq.component.annotations.widgets.CheckBox;
@@ -39,7 +40,11 @@ public class CheckboxWidgetMaker extends AbstractTouchUIWidgetMaker<CheckboxWidg
 		widgetParameters.setText(getTextForField(checkboxAnnotation));
 		widgetParameters.setTitle(getTitleForField(checkboxAnnotation));
 		widgetParameters.setChecked(getCheckedForField(checkboxAnnotation));
+		widgetParameters.setTouchUIDialogType(parameters.getTouchUIDialogType());
 
+		if(TouchUIDialogType.CORAL3.isOfType(widgetParameters.getTouchUIDialogType())) {
+			return new CheckboxCoral3Widget(widgetParameters);
+		}
 		return new CheckboxWidget(widgetParameters);
 	}
 
@@ -66,5 +71,4 @@ public class CheckboxWidgetMaker extends AbstractTouchUIWidgetMaker<CheckboxWidg
 
 		return new boolean[0];
 	}
-
 }

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/checkbox/CheckboxWidgetParameters.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/checkbox/CheckboxWidgetParameters.java
@@ -15,6 +15,7 @@
  */
 package com.citytechinc.cq.component.touchuidialog.widget.checkbox;
 
+import com.citytechinc.cq.component.touchuidialog.TouchUIDialogType;
 import com.citytechinc.cq.component.touchuidialog.widget.DefaultTouchUIWidgetParameters;
 
 public class CheckboxWidgetParameters extends DefaultTouchUIWidgetParameters {
@@ -51,6 +52,9 @@ public class CheckboxWidgetParameters extends DefaultTouchUIWidgetParameters {
 
 	@Override
 	public String getResourceType() {
+		if(TouchUIDialogType.CORAL3.isOfType(getTouchUIDialogType())) {
+			return CheckboxCoral3Widget.RESOURCE_TYPE;
+		}
 		return CheckboxWidget.RESOURCE_TYPE;
 	}
 
@@ -58,5 +62,4 @@ public class CheckboxWidgetParameters extends DefaultTouchUIWidgetParameters {
 	public void setResourceType(String resourceType) {
 		throw new UnsupportedOperationException("resourceType is Static for CheckboxWidget");
 	}
-
 }

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/datefield/DateFieldCoral3Widget.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/datefield/DateFieldCoral3Widget.java
@@ -1,0 +1,57 @@
+/**
+ *    Copyright 2017 ICF Olson
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.citytechinc.cq.component.touchuidialog.widget.datefield;
+
+import com.citytechinc.cq.component.annotations.config.TouchUIWidget;
+import com.citytechinc.cq.component.annotations.widgets.DateField;
+import com.citytechinc.cq.component.touchuidialog.widget.AbstractTouchUIWidget;
+
+@TouchUIWidget(annotationClass = DateField.class, makerClass = DateFieldWidgetMaker.class,
+	resourceType = DateFieldCoral3Widget.RESOURCE_TYPE)
+public class DateFieldCoral3Widget extends AbstractTouchUIWidget {
+
+	public static final String RESOURCE_TYPE = "granite/ui/components/coral/foundation/form/datepicker";
+
+	private final String minDate;
+	private final String maxDate;
+	private final String valueFormat; // default "YYYY-MM-DD[T]HH:mm:ss.000Z"
+	private final String displayedFormat;
+
+	public DateFieldCoral3Widget(DateFieldWidgetParameters parameters) {
+		super(parameters);
+
+		minDate = parameters.getMinDate();
+		maxDate = parameters.getMaxDate();
+		valueFormat = parameters.getValueFormat();
+		displayedFormat = parameters.getDisplayedFormat();
+	}
+
+	public String getMinDate() {
+		return minDate;
+	}
+
+	public String getMaxDate() {
+		return maxDate;
+	}
+
+	public String getValueFormat() {
+		return valueFormat;
+	}
+
+	public String getDisplayedFormat() {
+		return displayedFormat;
+	}
+}

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/datefield/DateFieldWidgetMaker.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/datefield/DateFieldWidgetMaker.java
@@ -15,6 +15,7 @@
  */
 package com.citytechinc.cq.component.touchuidialog.widget.datefield;
 
+import com.citytechinc.cq.component.touchuidialog.TouchUIDialogType;
 import org.codehaus.plexus.util.StringUtils;
 
 import com.citytechinc.cq.component.annotations.widgets.DateField;
@@ -35,9 +36,14 @@ public class DateFieldWidgetMaker extends AbstractTouchUIWidgetMaker<DateFieldWi
 
 		widgetParameters.setDisplayedFormat(getDisplayedFormatForField(annotation));
 		widgetParameters.setStoredFormat(getStoredFormatForField(annotation));
+		widgetParameters.setValueFormat(getValueFormatForField(annotation));
 		widgetParameters.setMinDate(getMinDateForField(annotation));
 		widgetParameters.setMaxDate(getMaxDateForField(annotation));
+		widgetParameters.setTouchUIDialogType(parameters.getTouchUIDialogType());
 
+		if(TouchUIDialogType.CORAL3.isOfType(widgetParameters.getTouchUIDialogType())) {
+			return new DateFieldCoral3Widget(widgetParameters);
+		}
 		return new DateFieldWidget(widgetParameters);
 	}
 
@@ -69,4 +75,7 @@ public class DateFieldWidgetMaker extends AbstractTouchUIWidgetMaker<DateFieldWi
 		return annotation.storedFormat();
 	}
 
+	protected String getValueFormatForField(DateField annotation) {
+		return annotation.valueFormat();
+	}
 }

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/datefield/DateFieldWidgetParameters.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/datefield/DateFieldWidgetParameters.java
@@ -15,6 +15,7 @@
  */
 package com.citytechinc.cq.component.touchuidialog.widget.datefield;
 
+import com.citytechinc.cq.component.touchuidialog.TouchUIDialogType;
 import com.citytechinc.cq.component.touchuidialog.widget.DefaultTouchUIWidgetParameters;
 
 public class DateFieldWidgetParameters extends DefaultTouchUIWidgetParameters {
@@ -22,6 +23,7 @@ public class DateFieldWidgetParameters extends DefaultTouchUIWidgetParameters {
 	protected String minDate;
 	protected String maxDate;
 	protected String storedFormat; // default "YYYY-MM-DD[T]HH:mm:ss.000Z"
+	protected String valueFormat; // default "YYYY-MM-DD[T]HH:mm:ss.000Z"
 	protected String displayedFormat;
 
 	public String getMinDate() {
@@ -48,6 +50,14 @@ public class DateFieldWidgetParameters extends DefaultTouchUIWidgetParameters {
 		this.storedFormat = storedFormat;
 	}
 
+	public String getValueFormat() {
+		return valueFormat;
+	}
+
+	public void setValueFormat(String valueFormat) {
+		this.valueFormat = valueFormat;
+	}
+
 	public String getDisplayedFormat() {
 		return displayedFormat;
 	}
@@ -58,6 +68,9 @@ public class DateFieldWidgetParameters extends DefaultTouchUIWidgetParameters {
 
 	@Override
 	public String getResourceType() {
+		if(TouchUIDialogType.CORAL3.isOfType(getTouchUIDialogType())) {
+			return DateFieldCoral3Widget.RESOURCE_TYPE;
+		}
 		return DateFieldWidget.RESOURCE_TYPE;
 	}
 
@@ -65,5 +78,4 @@ public class DateFieldWidgetParameters extends DefaultTouchUIWidgetParameters {
 	public void setResourceType(String resourceType) {
 		throw new UnsupportedOperationException("resourceType is Static for DateFieldWidget");
 	}
-
 }

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/datetime/DateTimeCoral3Widget.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/datetime/DateTimeCoral3Widget.java
@@ -1,0 +1,35 @@
+/**
+ *    Copyright 2017 ICF Olson
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.citytechinc.cq.component.touchuidialog.widget.datetime;
+
+import com.citytechinc.cq.component.annotations.config.TouchUIWidget;
+import com.citytechinc.cq.component.annotations.widgets.DateTime;
+import com.citytechinc.cq.component.touchuidialog.widget.datefield.DateFieldCoral3Widget;
+
+@TouchUIWidget(annotationClass = DateTime.class, makerClass = DateTimeWidgetMaker.class,
+	resourceType = DateTimeCoral3Widget.RESOURCE_TYPE)
+public class DateTimeCoral3Widget extends DateFieldCoral3Widget {
+
+	public static final String RESOURCE_TYPE = DateFieldCoral3Widget.RESOURCE_TYPE;
+
+	public DateTimeCoral3Widget(DateTimeWidgetParameters parameters) {
+		super(parameters);
+	}
+
+	public String getType() {
+		return "datetime";
+	}
+}

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/datetime/DateTimeWidgetMaker.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/datetime/DateTimeWidgetMaker.java
@@ -15,12 +15,12 @@
  */
 package com.citytechinc.cq.component.touchuidialog.widget.datetime;
 
-import org.codehaus.plexus.util.StringUtils;
-
 import com.citytechinc.cq.component.annotations.widgets.DateTime;
 import com.citytechinc.cq.component.touchuidialog.TouchUIDialogElement;
+import com.citytechinc.cq.component.touchuidialog.TouchUIDialogType;
 import com.citytechinc.cq.component.touchuidialog.widget.maker.AbstractTouchUIWidgetMaker;
 import com.citytechinc.cq.component.touchuidialog.widget.maker.TouchUIWidgetMakerParameters;
+import org.codehaus.plexus.util.StringUtils;
 
 public class DateTimeWidgetMaker extends AbstractTouchUIWidgetMaker<DateTimeWidgetParameters> {
 
@@ -36,9 +36,15 @@ public class DateTimeWidgetMaker extends AbstractTouchUIWidgetMaker<DateTimeWidg
 
 		widgetParameters.setDisplayedFormat(getDisplayedFormatForField(annotation));
 		widgetParameters.setStoredFormat(getStoredFormatForField(annotation));
+		widgetParameters.setValueFormat(getValueFormatForField(annotation));
 		widgetParameters.setMinDate(getMinDateForField(annotation));
 		widgetParameters.setMaxDate(getMaxDateForField(annotation));
+		widgetParameters.setTouchUIDialogType(parameters.getTouchUIDialogType());
 
+
+		if(TouchUIDialogType.CORAL3.isOfType(widgetParameters.getTouchUIDialogType())) {
+			return new DateTimeCoral3Widget(widgetParameters);
+		}
 		return new DateTimeWidget(widgetParameters);
 	}
 
@@ -74,4 +80,7 @@ public class DateTimeWidgetMaker extends AbstractTouchUIWidgetMaker<DateTimeWidg
 		return null;
 	}
 
+	protected String getValueFormatForField(DateTime annotation) {
+		return annotation.valueFormat();
+	}
 }

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/datetime/DateTimeWidgetParameters.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/datetime/DateTimeWidgetParameters.java
@@ -15,12 +15,16 @@
  */
 package com.citytechinc.cq.component.touchuidialog.widget.datetime;
 
+import com.citytechinc.cq.component.touchuidialog.TouchUIDialogType;
 import com.citytechinc.cq.component.touchuidialog.widget.datefield.DateFieldWidgetParameters;
 
 public class DateTimeWidgetParameters extends DateFieldWidgetParameters {
 
 	@Override
 	public String getResourceType() {
+		if(TouchUIDialogType.CORAL3.isOfType(getTouchUIDialogType())) {
+			return DateTimeCoral3Widget.RESOURCE_TYPE;
+		}
 		return DateTimeWidget.RESOURCE_TYPE;
 	}
 

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/dialogfieldset/DialogFieldSetCoral3Widget.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/dialogfieldset/DialogFieldSetCoral3Widget.java
@@ -1,0 +1,49 @@
+/**
+ *    Copyright 2017 ICF Olson
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.citytechinc.cq.component.touchuidialog.widget.dialogfieldset;
+
+import com.citytechinc.cq.component.annotations.config.TouchUIWidget;
+import com.citytechinc.cq.component.annotations.widgets.DialogFieldSet;
+import com.citytechinc.cq.component.touchuidialog.widget.AbstractTouchUIWidget;
+import com.citytechinc.cq.component.util.Constants;
+import com.citytechinc.cq.component.xml.NameSpacedAttribute;
+
+@TouchUIWidget(annotationClass = DialogFieldSet.class, makerClass = DialogFieldSetWidgetMaker.class,
+    resourceType = DialogFieldSetCoral3Widget.RESOURCE_TYPE)
+public class DialogFieldSetCoral3Widget extends AbstractTouchUIWidget {
+
+    public static final String RESOURCE_TYPE = "granite/ui/components/coral/foundation/form/fieldset";
+
+    private final String text;
+
+    private final NameSpacedAttribute<String> jcrTitle;
+
+    public DialogFieldSetCoral3Widget(DialogFieldSetWidgetParameters parameters) {
+        super(parameters);
+
+        text = parameters.getText();
+        jcrTitle = new NameSpacedAttribute<String>(Constants.JCR_NS_URI, Constants.JCR_NS_PREFIX, "title",
+            parameters.getJcrTitle());
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public NameSpacedAttribute<String> getJcrTitle() {
+        return jcrTitle;
+    }
+}

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/dialogfieldset/DialogFieldSetWidgetMaker.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/dialogfieldset/DialogFieldSetWidgetMaker.java
@@ -25,6 +25,7 @@ import com.citytechinc.cq.component.dialog.util.DialogUtil;
 import com.citytechinc.cq.component.maven.util.ComponentMojoUtil;
 import com.citytechinc.cq.component.touchuidialog.TouchUIDialogElement;
 import com.citytechinc.cq.component.touchuidialog.TouchUIDialogElementComparator;
+import com.citytechinc.cq.component.touchuidialog.TouchUIDialogType;
 import com.citytechinc.cq.component.touchuidialog.exceptions.TouchUIDialogGenerationException;
 import com.citytechinc.cq.component.touchuidialog.widget.factory.TouchUIWidgetFactory;
 import com.citytechinc.cq.component.touchuidialog.widget.maker.AbstractTouchUIWidgetMaker;
@@ -54,6 +55,7 @@ public class DialogFieldSetWidgetMaker extends AbstractTouchUIWidgetMaker<Dialog
         widgetParameters.setName(null);
         widgetParameters.setRequired(true);
         widgetParameters.setText(getFieldLabelForField());
+        widgetParameters.setTouchUIDialogType(parameters.getTouchUIDialogType());
 
         String title = null;
 
@@ -72,6 +74,9 @@ public class DialogFieldSetWidgetMaker extends AbstractTouchUIWidgetMaker<Dialog
                     + parameters.getContainingClass().getName(), e);
         }
 
+	    if(TouchUIDialogType.CORAL3.isOfType(widgetParameters.getTouchUIDialogType())) {
+		    return new DialogFieldSetCoral3Widget(widgetParameters);
+	    }
         return new DialogFieldSetWidget(widgetParameters);
 
     }
@@ -128,6 +133,7 @@ public class DialogFieldSetWidgetMaker extends AbstractTouchUIWidgetMaker<Dialog
                     curFieldMember.setClassPool(parameters.getClassPool());
                     curFieldMember.setWidgetRegistry(parameters.getWidgetRegistry());
                     curFieldMember.setUseDotSlashInName(parameters.isUseDotSlashInName());
+                    curFieldMember.setTouchUIDialogType(parameters.getTouchUIDialogType());
 
                     TouchUIDialogElement currentDialogElement = TouchUIWidgetFactory.make(curFieldMember, -1);
 

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/dialogfieldset/DialogFieldSetWidgetParameters.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/dialogfieldset/DialogFieldSetWidgetParameters.java
@@ -16,6 +16,7 @@
 package com.citytechinc.cq.component.touchuidialog.widget.dialogfieldset;
 
 import com.citytechinc.cq.component.touchuidialog.TouchUIDialogElement;
+import com.citytechinc.cq.component.touchuidialog.TouchUIDialogType;
 import com.citytechinc.cq.component.touchuidialog.container.items.Items;
 import com.citytechinc.cq.component.touchuidialog.container.items.ItemsParameters;
 import com.citytechinc.cq.component.touchuidialog.widget.DefaultTouchUIWidgetParameters;
@@ -99,6 +100,9 @@ public class DialogFieldSetWidgetParameters extends DefaultTouchUIWidgetParamete
 
     @Override
     public String getResourceType() {
+	    if(TouchUIDialogType.CORAL3.isOfType(getTouchUIDialogType())) {
+		    return DialogFieldSetCoral3Widget.RESOURCE_TYPE;
+	    }
         return DialogFieldSetWidget.RESOURCE_TYPE;
     }
 
@@ -106,5 +110,4 @@ public class DialogFieldSetWidgetParameters extends DefaultTouchUIWidgetParamete
     public void setResourceType(String resourceType) {
         throw new UnsupportedOperationException("resourceType is Static for DialogFieldSetWidget");
     }
-
 }

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/fileupload/FileUploadCoral3Widget.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/fileupload/FileUploadCoral3Widget.java
@@ -1,0 +1,126 @@
+/**
+ *    Copyright 2017 ICF Olson
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.citytechinc.cq.component.touchuidialog.widget.fileupload;
+
+import com.citytechinc.cq.component.annotations.config.TouchUIWidget;
+import com.citytechinc.cq.component.annotations.widgets.Html5SmartFile;
+import com.citytechinc.cq.component.touchuidialog.widget.AbstractTouchUIWidget;
+
+import java.util.List;
+
+@TouchUIWidget(annotationClass = Html5SmartFile.class, makerClass = FileUploadWidgetMaker.class,
+	resourceType = FileUploadCoral3Widget.RESOURCE_TYPE)
+public class FileUploadCoral3Widget extends AbstractTouchUIWidget {
+
+	/*
+	At the moment, coral 3 fileupload supports only uploads from local machine,
+	drag&drop from DAM doesn't work.
+
+	TODO: Update resource type when fileupload works as expected
+	public static final String RESOURCE_TYPE = "granite/ui/components/coral/foundation/form/fileupload";
+	*/
+	public static final String RESOURCE_TYPE = "cq/gui/components/authoring/dialog/fileupload";
+
+	private final boolean async;
+	private final String text;
+	private boolean hideText;
+	private final String icon;
+	private final String iconSize;
+	private final String size;
+	private final boolean multiple;
+	private final String uploadUrl;
+	private final Long sizeLimit;
+	private final boolean autoStart;
+	// TODO: Event handling ?
+	private final List<String> mimeTypes;
+	private final String fileNameParameter;
+	private final String fileReferenceParameter;
+	private final boolean allowUpload;
+
+	public FileUploadCoral3Widget(FileUploadWidgetParameters parameters) {
+		super(parameters);
+		async = parameters.isAsync();
+		text = parameters.getText();
+		hideText = parameters.isHideText();
+		icon = parameters.getIcon();
+		iconSize = parameters.getIconSize();
+		size = parameters.getSize();
+		multiple = parameters.isMultiple();
+		uploadUrl = parameters.getUploadUrl();
+		sizeLimit = parameters.getSizeLimit();
+		autoStart = parameters.isAutoStart();
+		fileNameParameter = parameters.getFileNameParameter();
+		fileReferenceParameter = parameters.getFileReferenceParameter();
+		mimeTypes = parameters.getMimeTypes();
+		allowUpload = parameters.isAllowUpload();
+	}
+
+	public boolean isAsync() {
+		return async;
+	}
+
+	public String getText() {
+		return text;
+	}
+
+	public boolean isHideText() {
+		return hideText;
+	}
+
+	public String getIcon() {
+		return icon;
+	}
+
+	public String getIconSize() {
+		return iconSize;
+	}
+
+	public String getSize() {
+		return size;
+	}
+
+	public boolean isMultiple() {
+		return multiple;
+	}
+
+	public String getUploadUrl() {
+		return uploadUrl;
+	}
+
+	public Long getSizeLimit() {
+		return sizeLimit;
+	}
+
+	public boolean isAutoStart() {
+		return autoStart;
+	}
+
+	public List<String> getMimeTypes() {
+		return mimeTypes;
+	}
+
+	public String getFileNameParameter() {
+		return fileNameParameter;
+	}
+
+	public String getFileReferenceParameter() {
+		return fileReferenceParameter;
+	}
+
+	public boolean isAllowUpload() {
+		return allowUpload;
+	}
+}

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/fileupload/FileUploadWidget.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/fileupload/FileUploadWidget.java
@@ -15,11 +15,11 @@
  */
 package com.citytechinc.cq.component.touchuidialog.widget.fileupload;
 
-import java.util.List;
-
 import com.citytechinc.cq.component.annotations.config.TouchUIWidget;
 import com.citytechinc.cq.component.annotations.widgets.Html5SmartFile;
 import com.citytechinc.cq.component.touchuidialog.widget.AbstractTouchUIWidget;
+
+import java.util.List;
 
 @TouchUIWidget(annotationClass = Html5SmartFile.class, makerClass = FileUploadWidgetMaker.class,
 	resourceType = FileUploadWidget.RESOURCE_TYPE)
@@ -40,6 +40,8 @@ public class FileUploadWidget extends AbstractTouchUIWidget {
 	private final String dropZone;
 	// TODO: Event handling ?
 	private final List<String> mimeTypes;
+	private final String fileNameParameter;
+	private final String fileReferenceParameter;
 
 	public FileUploadWidget(FileUploadWidgetParameters parameters) {
 		super(parameters);
@@ -55,6 +57,8 @@ public class FileUploadWidget extends AbstractTouchUIWidget {
 		useHTML5 = parameters.isUseHTML5();
 		dropZone = parameters.getDropZone();
 		mimeTypes = parameters.getMimeTypes();
+		fileNameParameter = parameters.getFileNameParameter();
+		fileReferenceParameter = parameters.getFileReferenceParameter();
 	}
 
 	@Override
@@ -104,5 +108,13 @@ public class FileUploadWidget extends AbstractTouchUIWidget {
 
 	public List<String> getMimeTypes() {
 		return mimeTypes;
+	}
+
+	public String getFileNameParameter() {
+		return fileNameParameter;
+	}
+
+	public String getFileReferenceParameter() {
+		return fileReferenceParameter;
 	}
 }

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/fileupload/FileUploadWidgetMaker.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/fileupload/FileUploadWidgetMaker.java
@@ -15,17 +15,17 @@
  */
 package com.citytechinc.cq.component.touchuidialog.widget.fileupload;
 
-import java.util.Arrays;
-import java.util.List;
-
-import org.codehaus.plexus.util.StringUtils;
-
 import com.citytechinc.cq.component.annotations.widgets.Html5SmartFile;
 import com.citytechinc.cq.component.dialog.exception.InvalidComponentFieldException;
 import com.citytechinc.cq.component.touchuidialog.TouchUIDialogElement;
+import com.citytechinc.cq.component.touchuidialog.TouchUIDialogType;
 import com.citytechinc.cq.component.touchuidialog.exceptions.TouchUIDialogGenerationException;
 import com.citytechinc.cq.component.touchuidialog.widget.maker.AbstractTouchUIWidgetMaker;
 import com.citytechinc.cq.component.touchuidialog.widget.maker.TouchUIWidgetMakerParameters;
+import org.codehaus.plexus.util.StringUtils;
+
+import java.util.Arrays;
+import java.util.List;
 
 public class FileUploadWidgetMaker extends AbstractTouchUIWidgetMaker<FileUploadWidgetParameters> {
 
@@ -39,8 +39,12 @@ public class FileUploadWidgetMaker extends AbstractTouchUIWidgetMaker<FileUpload
 		Html5SmartFile smartFileAnnotation = getAnnotation(Html5SmartFile.class);
 
 		widgetParameters.setTitle(getTitleForField(smartFileAnnotation));
+		widgetParameters.setAsync(getAsyncForField(smartFileAnnotation));
 		widgetParameters.setText(getTextForField(smartFileAnnotation));
+		widgetParameters.setHideText(getHideTextForField(smartFileAnnotation));
 		widgetParameters.setIcon(getIconForField(smartFileAnnotation));
+		widgetParameters.setIconSize(getIconSizeForField(smartFileAnnotation));
+		widgetParameters.setSize(getSizeForField(smartFileAnnotation));
 		widgetParameters.setMultiple(getMultipleForField(smartFileAnnotation));
 		widgetParameters.setAllowUpload(getAllowUploadForField(smartFileAnnotation));
 		widgetParameters.setUploadUrl(getUploadUrlForField(smartFileAnnotation));
@@ -50,7 +54,13 @@ public class FileUploadWidgetMaker extends AbstractTouchUIWidgetMaker<FileUpload
 		widgetParameters.setUseHTML5(getUseHTML5ForField(smartFileAnnotation));
 		widgetParameters.setDropZone(getDropZoneForField(smartFileAnnotation));
 		widgetParameters.setMimeTypes(getMimeTypesForField(smartFileAnnotation));
+		widgetParameters.setFileNameParameter(getFileNameParameterForField(smartFileAnnotation));
+		widgetParameters.setFileReferenceParameter(getFileReferenceParameterForField(smartFileAnnotation));
+		widgetParameters.setTouchUIDialogType(parameters.getTouchUIDialogType());
 
+		if(TouchUIDialogType.CORAL3.isOfType(widgetParameters.getTouchUIDialogType())) {
+			return new FileUploadCoral3Widget(widgetParameters);
+		}
 		return new FileUploadWidget(widgetParameters);
 	}
 
@@ -62,6 +72,14 @@ public class FileUploadWidgetMaker extends AbstractTouchUIWidgetMaker<FileUpload
 		return null;
 	}
 
+	public boolean getAsyncForField(Html5SmartFile annotation) {
+		if (annotation != null) {
+			return annotation.async();
+		}
+
+		return false;
+	}
+
 	public String getTextForField(Html5SmartFile annotation) {
 		if (annotation != null && StringUtils.isNotBlank(annotation.text())) {
 			return annotation.text();
@@ -70,6 +88,13 @@ public class FileUploadWidgetMaker extends AbstractTouchUIWidgetMaker<FileUpload
 		return null;
 	}
 
+	public boolean getHideTextForField(Html5SmartFile annotation) {
+		if (annotation != null) {
+			return annotation.hideText();
+		}
+
+		return false;
+	}
 	public String getIconForField(Html5SmartFile annotation) {
 		if (annotation != null && StringUtils.isNotBlank(annotation.icon())) {
 			return annotation.icon();
@@ -86,20 +111,28 @@ public class FileUploadWidgetMaker extends AbstractTouchUIWidgetMaker<FileUpload
 		return false;
 	}
 
+	public String getIconSizeForField(Html5SmartFile annotation) {
+		if (annotation != null && StringUtils.isNotBlank(annotation.iconSize())) {
+			return annotation.iconSize();
+		}
+
+		return null;
+	}
+
+	public String getSizeForField(Html5SmartFile annotation) {
+		if (annotation != null && StringUtils.isNotBlank(annotation.size())) {
+			return annotation.size();
+		}
+
+		return null;
+	}
+
 	public boolean getMultipleForField(Html5SmartFile annotation) {
 		if (annotation != null) {
 			return annotation.multiple();
 		}
 
 		return false;
-	}
-
-	public String getFileNameParameterForField(Html5SmartFile annotation) {
-		if (annotation != null && StringUtils.isNotBlank(annotation.fileNameParameter())) {
-			return annotation.fileNameParameter();
-		}
-
-		return null;
 	}
 
 	public String getUploadUrlForField(Html5SmartFile annotation) {
@@ -156,5 +189,13 @@ public class FileUploadWidgetMaker extends AbstractTouchUIWidgetMaker<FileUpload
 		}
 
 		return null;
+	}
+
+	private String getFileReferenceParameterForField(Html5SmartFile smartFileAnnotation) {
+		return smartFileAnnotation.fileReferenceParameter();
+	}
+
+	private String getFileNameParameterForField(Html5SmartFile smartFileAnnotation) {
+		return smartFileAnnotation.fileNameParameter();
 	}
 }

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/fileupload/FileUploadWidgetParameters.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/fileupload/FileUploadWidgetParameters.java
@@ -1,154 +1,203 @@
 /**
- * Copyright 2017 ICF Olson
- * <p>
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ *    Copyright 2017 ICF Olson
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
  */
 package com.citytechinc.cq.component.touchuidialog.widget.fileupload;
 
+import com.citytechinc.cq.component.touchuidialog.TouchUIDialogType;
 import com.citytechinc.cq.component.touchuidialog.widget.DefaultTouchUIWidgetParameters;
 
 import java.util.List;
 
 public class FileUploadWidgetParameters extends DefaultTouchUIWidgetParameters {
 
-    private String title;
+	private String title;
+	private boolean async;
+	private String text;
+	private boolean hideText;
+	private String icon;
+	private String iconSize;
+	private String size;
+	private boolean multiple;
+	private String uploadUrl;
+	private String uploadUrlBuilder;
+	private Long sizeLimit;
+	private boolean autoStart;
+	private boolean useHTML5;
+	private String dropZone;
+	// TODO: Event handling
+	private List<String> mimeTypes;
+	private boolean allowUpload;
+	private String fileNameParameter;
+	private String fileReferenceParameter;
 
-    private String text;
+	@Override
+	public String getTitle() {
+		return title;
+	}
 
-    private String icon;
+	@Override
+	public void setTitle(String title) {
+		this.title = title;
+	}
 
-    private boolean multiple;
+	public boolean isAsync() {
+		return async;
+	}
 
-    private boolean allowUpload;
+	public void setAsync(boolean async) {
+		this.async = async;
+	}
 
-    private String uploadUrl;
+	public String getText() {
+		return text;
+	}
 
-    private String uploadUrlBuilder;
+	public void setText(String text) {
+		this.text = text;
+	}
 
-    private Long sizeLimit;
+	public boolean isHideText() {
+		return hideText;
+	}
 
-    private boolean autoStart;
+	public void setHideText(boolean hideText) {
+		this.hideText = hideText;
+	}
 
-    private boolean useHTML5;
+	public String getIcon() {
+		return icon;
+	}
 
-    private String dropZone;
+	public void setIcon(String icon) {
+		this.icon = icon;
+	}
 
-    // TODO: Event handling
-    private List<String> mimeTypes;
+	public String getIconSize() {
+		return iconSize;
+	}
 
-    @Override
-    public String getTitle() {
-        return title;
-    }
+	public void setIconSize(String iconSize) {
+		this.iconSize = iconSize;
+	}
 
-    @Override
-    public void setTitle(String title) {
-        this.title = title;
-    }
+	public String getSize() {
+		return size;
+	}
 
-    public String getText() {
-        return text;
-    }
+	public void setSize(String size) {
+		this.size = size;
+	}
 
-    public void setText(String text) {
-        this.text = text;
-    }
+	public boolean isMultiple() {
+		return multiple;
+	}
 
-    public String getIcon() {
-        return icon;
-    }
+	public void setMultiple(boolean multiple) {
+		this.multiple = multiple;
+	}
 
-    public void setIcon(String icon) {
-        this.icon = icon;
-    }
+	public String getUploadUrl() {
+		return uploadUrl;
+	}
 
-    public boolean isMultiple() {
-        return multiple;
-    }
+	public void setUploadUrl(String uploadUrl) {
+		this.uploadUrl = uploadUrl;
+	}
 
-    public void setMultiple(boolean multiple) {
-        this.multiple = multiple;
-    }
+	public String getUploadUrlBuilder() {
+		return uploadUrlBuilder;
+	}
 
-    public boolean isAllowUpload() {
-        return allowUpload;
-    }
+	public void setUploadUrlBuilder(String uploadUrlBuilder) {
+		this.uploadUrlBuilder = uploadUrlBuilder;
+	}
 
-    public void setAllowUpload(boolean allowUpload) {
-        this.allowUpload = allowUpload;
-    }
+	public Long getSizeLimit() {
+		return sizeLimit;
+	}
 
-    public String getUploadUrl() {
-        return uploadUrl;
-    }
+	public void setSizeLimit(Long sizeLimit) {
+		this.sizeLimit = sizeLimit;
+	}
 
-    public void setUploadUrl(String uploadUrl) {
-        this.uploadUrl = uploadUrl;
-    }
+	public boolean isAutoStart() {
+		return autoStart;
+	}
 
-    public String getUploadUrlBuilder() {
-        return uploadUrlBuilder;
-    }
+	public void setAutoStart(boolean autoStart) {
+		this.autoStart = autoStart;
+	}
 
-    public void setUploadUrlBuilder(String uploadUrlBuilder) {
-        this.uploadUrlBuilder = uploadUrlBuilder;
-    }
+	public boolean isUseHTML5() {
+		return useHTML5;
+	}
 
-    public Long getSizeLimit() {
-        return sizeLimit;
-    }
+	public void setUseHTML5(boolean useHTML5) {
+		this.useHTML5 = useHTML5;
+	}
 
-    public void setSizeLimit(Long sizeLimit) {
-        this.sizeLimit = sizeLimit;
-    }
+	public String getDropZone() {
+		return dropZone;
+	}
 
-    public boolean isAutoStart() {
-        return autoStart;
-    }
+	public void setDropZone(String dropZone) {
+		this.dropZone = dropZone;
+	}
 
-    public void setAutoStart(boolean autoStart) {
-        this.autoStart = autoStart;
-    }
+	public List<String> getMimeTypes() {
+		return mimeTypes;
+	}
 
-    public boolean isUseHTML5() {
-        return useHTML5;
-    }
+	public void setMimeTypes(List<String> mimeTypes) {
+		this.mimeTypes = mimeTypes;
+	}
 
-    public void setUseHTML5(boolean useHTML5) {
-        this.useHTML5 = useHTML5;
-    }
+	public boolean isAllowUpload() {
+		return allowUpload;
+	}
 
-    public String getDropZone() {
-        return dropZone;
-    }
+	public void setAllowUpload(boolean allowUpload) {
+		this.allowUpload = allowUpload;
+	}
 
-    public void setDropZone(String dropZone) {
-        this.dropZone = dropZone;
-    }
+	public String getFileNameParameter() {
+		return fileNameParameter;
+	}
 
-    public List<String> getMimeTypes() {
-        return mimeTypes;
-    }
+	public void setFileNameParameter(String fileNameParameter) {
+		this.fileNameParameter = fileNameParameter;
+	}
 
-    public void setMimeTypes(List<String> mimeTypes) {
-        this.mimeTypes = mimeTypes;
-    }
+	public String getFileReferenceParameter() {
+		return fileReferenceParameter;
+	}
 
-    @Override
-    public String getResourceType() {
-        return FileUploadWidget.RESOURCE_TYPE;
-    }
+	public void setFileReferenceParameter(String fileReferenceParameter) {
+		this.fileReferenceParameter = fileReferenceParameter;
+	}
 
-    @Override
-    public void setResourceType(String resourceType) {
-        throw new UnsupportedOperationException("resourceType is Static for FileUploadWidget");
-    }
+	@Override
+	public String getResourceType() {
+		if(TouchUIDialogType.CORAL3.isOfType(getTouchUIDialogType())) {
+			return FileUploadCoral3Widget.RESOURCE_TYPE;
+		}
+		return FileUploadWidget.RESOURCE_TYPE;
+	}
 
+	@Override
+	public void setResourceType(String resourceType) {
+		throw new UnsupportedOperationException("resourceType is Static for FileUploadWidget");
+	}
 }

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/multifield/MultiFieldCoral3Widget.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/multifield/MultiFieldCoral3Widget.java
@@ -1,0 +1,40 @@
+/**
+ *    Copyright 2017 ICF Olson
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.citytechinc.cq.component.touchuidialog.widget.multifield;
+
+import com.citytechinc.cq.component.annotations.config.TouchUIWidget;
+import com.citytechinc.cq.component.annotations.widgets.MultiField;
+import com.citytechinc.cq.component.touchuidialog.widget.AbstractTouchUIWidget;
+
+@TouchUIWidget(annotationClass = MultiField.class, makerClass = MultiFieldWidgetMaker.class,
+	resourceType = MultiFieldCoral3Widget.RESOURCE_TYPE, ranking = MultiFieldCoral3Widget.RANKING)
+public class MultiFieldCoral3Widget extends AbstractTouchUIWidget {
+
+	public static final String RESOURCE_TYPE = "granite/ui/components/coral/foundation/form/multifield";
+	public static final int RANKING = 1000000;
+
+	protected final boolean composite;
+
+	public MultiFieldCoral3Widget(MultiFieldWidgetParameters parameters) {
+		super(parameters);
+
+		composite = parameters.isComposite();
+	}
+
+	public boolean isComposite() {
+		return composite;
+	}
+}

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/multifield/MultiFieldWidgetMaker.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/multifield/MultiFieldWidgetMaker.java
@@ -15,35 +15,171 @@
  */
 package com.citytechinc.cq.component.touchuidialog.widget.multifield;
 
-import java.util.ArrayList;
-import java.util.List;
-
+import com.citytechinc.cq.component.annotations.DialogField;
+import com.citytechinc.cq.component.annotations.IgnoreDialogField;
+import com.citytechinc.cq.component.annotations.MultiFieldChildResource;
+import com.citytechinc.cq.component.annotations.widgets.MultiField;
+import com.citytechinc.cq.component.dialog.DialogFieldConfig;
+import com.citytechinc.cq.component.dialog.exception.InvalidComponentClassException;
 import com.citytechinc.cq.component.dialog.exception.InvalidComponentFieldException;
+import com.citytechinc.cq.component.dialog.util.DialogUtil;
+import com.citytechinc.cq.component.maven.util.ComponentMojoUtil;
 import com.citytechinc.cq.component.touchuidialog.TouchUIDialogElement;
+import com.citytechinc.cq.component.touchuidialog.TouchUIDialogElementComparator;
+import com.citytechinc.cq.component.touchuidialog.TouchUIDialogType;
+import com.citytechinc.cq.component.touchuidialog.container.Container;
+import com.citytechinc.cq.component.touchuidialog.container.ContainerParameters;
+import com.citytechinc.cq.component.touchuidialog.container.items.Items;
+import com.citytechinc.cq.component.touchuidialog.container.items.ItemsParameters;
 import com.citytechinc.cq.component.touchuidialog.exceptions.TouchUIDialogGenerationException;
 import com.citytechinc.cq.component.touchuidialog.widget.factory.TouchUIWidgetFactory;
 import com.citytechinc.cq.component.touchuidialog.widget.maker.AbstractTouchUIWidgetMaker;
 import com.citytechinc.cq.component.touchuidialog.widget.maker.TouchUIWidgetMakerParameters;
+import com.google.common.collect.ImmutableMap;
+import javassist.CtMember;
+import javassist.CtMethod;
+import javassist.NotFoundException;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 public class MultiFieldWidgetMaker extends AbstractTouchUIWidgetMaker<MultiFieldWidgetParameters> {
 
-	public MultiFieldWidgetMaker(TouchUIWidgetMakerParameters parameters) {
-		super(parameters);
-	}
+    public MultiFieldWidgetMaker(TouchUIWidgetMakerParameters parameters) {
+        super(parameters);
+    }
 
-	@Override
-	public TouchUIDialogElement make(MultiFieldWidgetParameters widgetParameters) throws ClassNotFoundException,
-		InvalidComponentFieldException, TouchUIDialogGenerationException {
+    @Override
+    public TouchUIDialogElement make(MultiFieldWidgetParameters widgetParameters) throws ClassNotFoundException,
+            InvalidComponentFieldException, TouchUIDialogGenerationException {
+        MultiField annotation = getAnnotation(MultiField.class);
+        List<TouchUIDialogElement> containedElements = new ArrayList<TouchUIDialogElement>();
 
-		TouchUIDialogElement field = TouchUIWidgetFactory.make(parameters, MultiFieldWidget.RANKING);
-		field.setFieldName("field");
+        if (isComposite(annotation)) {
+            try {
+                containedElements.add(generateFieldContainer(widgetParameters, this));
+            } catch (NotFoundException e) {
+                throw new TouchUIDialogGenerationException(
+                        "Exception encountered while constructing contained elements for the Multifield "
+                                + parameters.getDialogFieldConfig().getFieldName() + " of class "
+                                + parameters.getContainingClass().getName(), e);
+            }
+            // For coral 3 composite multifield, the name parameter should be inside the field tag
+            widgetParameters.setName("");
+        } else {
+            TouchUIDialogElement field = TouchUIWidgetFactory.make(parameters, MultiFieldWidget.RANKING);
+            field.setFieldName("field");
+            containedElements.add(field);
+        }
 
-		List<TouchUIDialogElement> containedElements = new ArrayList<TouchUIDialogElement>();
-		containedElements.add(field);
+        widgetParameters.setContainedElements(containedElements);
+        widgetParameters.setComposite(isComposite(annotation));
+        widgetParameters.setTouchUIDialogType(parameters.getTouchUIDialogType());
 
-		widgetParameters.setContainedElements(containedElements);
+        if (TouchUIDialogType.CORAL3.isOfType(widgetParameters.getTouchUIDialogType())) {
+            return new MultiFieldCoral3Widget(widgetParameters);
+        }
+        return new MultiFieldWidget(widgetParameters);
+    }
 
-		return new MultiFieldWidget(widgetParameters);
-	}
+    public TouchUIWidgetMakerParameters getParameters() {
+        return parameters;
+    }
 
+    protected boolean isComposite(MultiField annotation) {
+        if (annotation != null) {
+            return annotation.composite();
+        }
+        return false;
+    }
+
+    private Container generateFieldContainer(MultiFieldWidgetParameters widgetParameters, MultiFieldWidgetMaker widgetMaker)
+            throws NotFoundException, InvalidComponentFieldException, ClassNotFoundException, TouchUIDialogGenerationException {
+        ContainerParameters containerParameters = new ContainerParameters();
+
+        containerParameters.setFieldName("field");
+        containerParameters.setTouchUIDialogType(TouchUIDialogType.CORAL3.getType());
+        containerParameters.setContainedElements(generateItemsTag(widgetMaker));
+        containerParameters.setAdditionalProperties(ImmutableMap.of("name", widgetParameters.getName()));
+
+        return new Container(containerParameters);
+    }
+
+    private List<TouchUIDialogElement> generateItemsTag(MultiFieldWidgetMaker widgetMaker)
+            throws NotFoundException, InvalidComponentFieldException, ClassNotFoundException, TouchUIDialogGenerationException {
+        ItemsParameters itemsParameters = new ItemsParameters();
+
+        itemsParameters.setFieldName("items");
+        itemsParameters.setContainedElements(generateDialogElements(widgetMaker));
+        List<TouchUIDialogElement> itemsElements = new ArrayList<TouchUIDialogElement>();
+        itemsElements.add(new Items(itemsParameters));
+
+        return itemsElements;
+    }
+
+    private List<TouchUIDialogElement> generateDialogElements(MultiFieldWidgetMaker widgetMaker)
+            throws NotFoundException, InvalidComponentFieldException, ClassNotFoundException, TouchUIDialogGenerationException {
+        List<TouchUIDialogElement> dialogElements = new ArrayList<TouchUIDialogElement>();
+
+        buildDialogFields(dialogElements, widgetMaker);
+        Collections.sort(dialogElements, new TouchUIDialogElementComparator());
+
+        return dialogElements;
+    }
+
+    private static void buildDialogFields(List<TouchUIDialogElement> elements, MultiFieldWidgetMaker widgetMaker)
+            throws NotFoundException, InvalidComponentFieldException, ClassNotFoundException,
+            TouchUIDialogGenerationException {
+        List<CtMember> fieldsAndMethods = new ArrayList<CtMember>();
+        fieldsAndMethods.addAll(ComponentMojoUtil.collectFields(widgetMaker.getCtType()));
+        fieldsAndMethods.addAll(ComponentMojoUtil.collectMethods(widgetMaker.getCtType()));
+
+        for (CtMember member : fieldsAndMethods) {
+            if (!member.hasAnnotation(IgnoreDialogField.class)) {
+                DialogFieldConfig dialogFieldConfig = null;
+
+                if (member instanceof CtMethod) {
+                    try {
+                        dialogFieldConfig = DialogUtil.getDialogFieldFromSuperClasses((CtMethod) member);
+                    } catch (InvalidComponentClassException e) {
+                        throw new InvalidComponentFieldException(e.getMessage(), e);
+                    }
+                } else if (member.hasAnnotation(DialogField.class)) {
+                    dialogFieldConfig = new DialogFieldConfig((DialogField) member.getAnnotation(DialogField.class), member);
+                }
+
+                if (dialogFieldConfig != null && !dialogFieldConfig.isSuppressTouchUI()) {
+                    TouchUIWidgetMakerParameters curFieldMember = generateWidgetMakerParameters(member, widgetMaker, dialogFieldConfig);
+
+                    if (member.hasAnnotation(MultiFieldChildResource.class)) {
+                        buildDialogFields(elements, new MultiFieldWidgetMaker(curFieldMember));
+                    } else {
+                        TouchUIDialogElement currentDialogElement = TouchUIWidgetFactory.make(curFieldMember, -1);
+
+                        if (currentDialogElement != null) {
+                            currentDialogElement.setRanking(dialogFieldConfig.getRanking());
+                            elements.add(currentDialogElement);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private static TouchUIWidgetMakerParameters generateWidgetMakerParameters(CtMember member, MultiFieldWidgetMaker widgetMaker, DialogFieldConfig dialogFieldConfig)
+            throws ClassNotFoundException {
+        TouchUIWidgetMakerParameters widgetMakerParameters = new TouchUIWidgetMakerParameters();
+        Class<?> fieldClass = widgetMaker.getParameters().getClassLoader().loadClass(member.getDeclaringClass().getName());
+
+        widgetMakerParameters.setDialogFieldConfig(dialogFieldConfig);
+        widgetMakerParameters.setContainingClass(fieldClass);
+        widgetMakerParameters.setClassLoader(widgetMaker.getParameters().getClassLoader());
+        widgetMakerParameters.setClassPool(widgetMaker.getParameters().getClassPool());
+        widgetMakerParameters.setWidgetRegistry(widgetMaker.getParameters().getWidgetRegistry());
+        widgetMakerParameters.setUseDotSlashInName(widgetMaker.getParameters().isUseDotSlashInName());
+        widgetMakerParameters.setTouchUIDialogType(widgetMaker.getParameters().getTouchUIDialogType());
+
+        return widgetMakerParameters;
+    }
 }

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/multifield/MultiFieldWidgetParameters.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/multifield/MultiFieldWidgetParameters.java
@@ -15,11 +15,26 @@
  */
 package com.citytechinc.cq.component.touchuidialog.widget.multifield;
 
+import com.citytechinc.cq.component.touchuidialog.TouchUIDialogType;
 import com.citytechinc.cq.component.touchuidialog.widget.DefaultTouchUIWidgetParameters;
 
 public class MultiFieldWidgetParameters extends DefaultTouchUIWidgetParameters {
+
+	private boolean composite;
+
+	public boolean isComposite() {
+		return composite;
+	}
+
+	public void setComposite(boolean composite) {
+		this.composite = composite;
+	}
+
 	@Override
 	public String getResourceType() {
+		if(TouchUIDialogType.CORAL3.isOfType(getTouchUIDialogType())) {
+			return MultiFieldCoral3Widget.RESOURCE_TYPE;
+		}
 		return MultiFieldWidget.RESOURCE_TYPE;
 	}
 

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/numberfield/NumberFieldCoral3Widget.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/numberfield/NumberFieldCoral3Widget.java
@@ -1,0 +1,58 @@
+/**
+ *    Copyright 2017 ICF Olson
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.citytechinc.cq.component.touchuidialog.widget.numberfield;
+
+import com.citytechinc.cq.component.annotations.config.TouchUIWidget;
+import com.citytechinc.cq.component.annotations.widgets.NumberField;
+import com.citytechinc.cq.component.touchuidialog.widget.AbstractTouchUIWidget;
+
+@TouchUIWidget(annotationClass = NumberField.class, makerClass = NumberFieldWidgetMaker.class,
+	resourceType = NumberFieldCoral3Widget.RESOURCE_TYPE)
+public class NumberFieldCoral3Widget extends AbstractTouchUIWidget {
+
+	public static final String RESOURCE_TYPE = "granite/ui/components/coral/foundation/form/numberfield";
+
+	private final Double min;
+	private final Double max;
+	private final Double step;
+	private final String typeHint;
+
+	public NumberFieldCoral3Widget(NumberFieldWidgetParameters parameters) {
+		super(parameters);
+
+		min = parameters.getMin();
+		max = parameters.getMax();
+		step = parameters.getStep();
+		typeHint = parameters.getTypeHint();
+	}
+
+	public Double getMin() {
+		return min;
+	}
+
+	public Double getMax() {
+		return max;
+	}
+
+	public Double getStep() {
+		return step;
+	}
+
+	public String getTypeHint() {
+		return typeHint;
+	}
+
+}

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/numberfield/NumberFieldWidgetMaker.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/numberfield/NumberFieldWidgetMaker.java
@@ -15,6 +15,7 @@
  */
 package com.citytechinc.cq.component.touchuidialog.widget.numberfield;
 
+import com.citytechinc.cq.component.touchuidialog.TouchUIDialogType;
 import org.codehaus.plexus.util.StringUtils;
 
 import com.citytechinc.cq.component.annotations.widgets.NumberField;
@@ -37,7 +38,12 @@ public class NumberFieldWidgetMaker extends AbstractTouchUIWidgetMaker<NumberFie
 		widgetParameters.setMin(getMinForField(numberField));
 		widgetParameters.setMax(getMaxForField(numberField));
 		widgetParameters.setStep(getStepForField(numberField));
+		widgetParameters.setTypeHint(getTypeHintForField(numberField));
+		widgetParameters.setTouchUIDialogType(parameters.getTouchUIDialogType());
 
+		if(TouchUIDialogType.CORAL3.isOfType(widgetParameters.getTouchUIDialogType())) {
+			return new NumberFieldCoral3Widget(widgetParameters);
+		}
 		return new NumberFieldWidget(widgetParameters);
 	}
 
@@ -81,5 +87,13 @@ public class NumberFieldWidgetMaker extends AbstractTouchUIWidgetMaker<NumberFie
 						+ ". Non-integer steps will cause the increment and decrement buttons of the number field to misbehave.");
 		}
 		return step;
+	}
+
+	protected String getTypeHintForField(NumberField annotation) {
+		if (StringUtils.isNotBlank(annotation.typeHint())) {
+			return annotation.typeHint();
+		}
+
+		return null;
 	}
 }

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/numberfield/NumberFieldWidgetParameters.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/numberfield/NumberFieldWidgetParameters.java
@@ -15,6 +15,7 @@
  */
 package com.citytechinc.cq.component.touchuidialog.widget.numberfield;
 
+import com.citytechinc.cq.component.touchuidialog.TouchUIDialogType;
 import com.citytechinc.cq.component.touchuidialog.widget.DefaultTouchUIWidgetParameters;
 
 public class NumberFieldWidgetParameters extends DefaultTouchUIWidgetParameters {
@@ -22,6 +23,7 @@ public class NumberFieldWidgetParameters extends DefaultTouchUIWidgetParameters 
 	private Double min;
 	private Double max;
 	private Double step;
+	private String typeHint;
 
 	public Double getMin() {
 		return min;
@@ -47,8 +49,19 @@ public class NumberFieldWidgetParameters extends DefaultTouchUIWidgetParameters 
 		this.step = step;
 	}
 
+	public String getTypeHint() {
+		return typeHint;
+	}
+
+	public void setTypeHint(String typeHint) {
+		this.typeHint = typeHint;
+	}
+
 	@Override
 	public String getResourceType() {
+		if(TouchUIDialogType.CORAL3.isOfType(getTouchUIDialogType())) {
+			return NumberFieldCoral3Widget.RESOURCE_TYPE;
+		}
 		return NumberFieldWidget.RESOURCE_TYPE;
 	}
 

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/pathfield/PathFieldCoral3Widget.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/pathfield/PathFieldCoral3Widget.java
@@ -1,0 +1,52 @@
+/**
+ *    Copyright 2017 ICF Olson
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.citytechinc.cq.component.touchuidialog.widget.pathfield;
+
+import com.citytechinc.cq.component.annotations.config.TouchUIWidget;
+import com.citytechinc.cq.component.annotations.widgets.PathField;
+import com.citytechinc.cq.component.touchuidialog.widget.AbstractTouchUIWidget;
+
+@TouchUIWidget(annotationClass = PathField.class, makerClass = PathFieldWidgetMaker.class,
+	resourceType = PathFieldCoral3Widget.RESOURCE_TYPE)
+public class PathFieldCoral3Widget extends AbstractTouchUIWidget {
+
+	public static final String RESOURCE_TYPE = "granite/ui/components/coral/foundation/form/pathfield";
+
+	private final String rootPath;
+	private final boolean forceSelection;
+	private final String filter;
+
+
+	public PathFieldCoral3Widget(PathFieldWidgetParameters parameters) {
+		super(parameters);
+
+		rootPath = parameters.getRootPath();
+		forceSelection = parameters.isForceSelection();
+		filter = parameters.getFilter();
+	}
+
+	public String getRootPath() {
+		return rootPath;
+	}
+
+	public boolean isForceSelection() {
+		return forceSelection;
+	}
+
+	public String getFilter() {
+		return filter;
+	}
+}

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/pathfield/PathFieldWidgetMaker.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/pathfield/PathFieldWidgetMaker.java
@@ -15,6 +15,7 @@
  */
 package com.citytechinc.cq.component.touchuidialog.widget.pathfield;
 
+import com.citytechinc.cq.component.touchuidialog.TouchUIDialogType;
 import org.codehaus.plexus.util.StringUtils;
 
 import com.citytechinc.cq.component.annotations.widgets.PathField;
@@ -40,7 +41,13 @@ public class PathFieldWidgetMaker extends AbstractTouchUIWidgetMaker<PathFieldWi
 		widgetParameters.setOptionLoaderRoot(getOptionLoaderRootForField(pathFieldAnnotation));
 		widgetParameters.setOptionValueReader(getOptionValueReaderForField(pathFieldAnnotation));
 		widgetParameters.setOptionTitleReader(getOptionTitleReaderForField(pathFieldAnnotation));
+		widgetParameters.setForceSelection(getForceSelectionForField(pathFieldAnnotation));
+		widgetParameters.setFilter(getFilterForField(pathFieldAnnotation));
+		widgetParameters.setTouchUIDialogType(parameters.getTouchUIDialogType());
 
+		if(TouchUIDialogType.CORAL3.isOfType(widgetParameters.getTouchUIDialogType())) {
+			return new PathFieldCoral3Widget(widgetParameters);
+		}
 		return new PathFieldWidget(widgetParameters);
 	}
 
@@ -80,4 +87,19 @@ public class PathFieldWidgetMaker extends AbstractTouchUIWidgetMaker<PathFieldWi
 		return null;
 	}
 
+	public boolean getForceSelectionForField(PathField annotation) {
+		if (annotation != null) {
+			return annotation.forceSelection();
+		}
+
+		return false;
+	}
+
+	public String getFilterForField(PathField annotation) {
+		if (annotation != null && StringUtils.isNotBlank(annotation.filter())) {
+			return annotation.filter();
+		}
+
+		return null;
+	}
 }

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/pathfield/PathFieldWidgetParameters.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/pathfield/PathFieldWidgetParameters.java
@@ -15,6 +15,7 @@
  */
 package com.citytechinc.cq.component.touchuidialog.widget.pathfield;
 
+import com.citytechinc.cq.component.touchuidialog.TouchUIDialogType;
 import com.citytechinc.cq.component.touchuidialog.widget.DefaultTouchUIWidgetParameters;
 
 public class PathFieldWidgetParameters extends DefaultTouchUIWidgetParameters {
@@ -24,6 +25,8 @@ public class PathFieldWidgetParameters extends DefaultTouchUIWidgetParameters {
 	private String optionLoaderRoot;
 	private String optionValueReader;
 	private String optionTitleReader;
+	private boolean forceSelection;
+	private String filter;
 
 	public String getRootPath() {
 		return rootPath;
@@ -65,8 +68,27 @@ public class PathFieldWidgetParameters extends DefaultTouchUIWidgetParameters {
 		this.optionTitleReader = optionTitleReader;
 	}
 
+	public boolean isForceSelection() {
+		return forceSelection;
+	}
+
+	public void setForceSelection(boolean forceSelection) {
+		this.forceSelection = forceSelection;
+	}
+
+	public String getFilter() {
+		return filter;
+	}
+
+	public void setFilter(String filter) {
+		this.filter = filter;
+	}
+
 	@Override
 	public String getResourceType() {
+		if(TouchUIDialogType.CORAL3.isOfType(getTouchUIDialogType())) {
+			return PathFieldCoral3Widget.RESOURCE_TYPE;
+		}
 		return PathFieldWidget.RESOURCE_TYPE;
 	}
 

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/radiogroup/RadioGroupCoral3Widget.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/radiogroup/RadioGroupCoral3Widget.java
@@ -1,0 +1,37 @@
+/**
+ *    Copyright 2017 ICF Olson
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.citytechinc.cq.component.touchuidialog.widget.radiogroup;
+
+import com.citytechinc.cq.component.touchuidialog.widget.AbstractTouchUIWidget;
+
+public class RadioGroupCoral3Widget extends AbstractTouchUIWidget {
+
+	public static final String RESOURCE_TYPE = "granite/ui/components/coral/foundation/form/radiogroup";
+
+	private final String text;
+
+	public RadioGroupCoral3Widget(RadioGroupWidgetParameters parameters) {
+
+		super(parameters);
+
+		text = parameters.getText();
+
+	}
+
+	public String getText() {
+		return text;
+	}
+}

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/radiogroup/RadioGroupWidgetMaker.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/radiogroup/RadioGroupWidgetMaker.java
@@ -15,6 +15,7 @@
  */
 package com.citytechinc.cq.component.touchuidialog.widget.radiogroup;
 
+import com.citytechinc.cq.component.touchuidialog.TouchUIDialogType;
 import org.codehaus.plexus.util.StringUtils;
 
 import com.citytechinc.cq.component.annotations.widgets.Selection;
@@ -40,10 +41,13 @@ public class RadioGroupWidgetMaker extends AbstractTouchUIWidgetMaker<RadioGroup
 
 		widgetParameters.setText(getFieldLabelForField());
 		widgetParameters.setDataSource(getDataSourceForField(selectionField));
-
 		widgetParameters.setOptions(TouchUIDialogUtil.getOptionsForSelection(selectionField, getType(),
 			parameters.getClassLoader(), parameters.getClassPool()));
+		widgetParameters.setTouchUIDialogType(parameters.getTouchUIDialogType());
 
+		if(TouchUIDialogType.CORAL3.isOfType(widgetParameters.getTouchUIDialogType())) {
+			return new RadioGroupCoral3Widget(widgetParameters);
+		}
 		return new RadioGroupWidget(widgetParameters);
 	}
 

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/radiogroup/RadioGroupWidgetParameters.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/radiogroup/RadioGroupWidgetParameters.java
@@ -15,15 +15,16 @@
  */
 package com.citytechinc.cq.component.touchuidialog.widget.radiogroup;
 
-import java.util.ArrayList;
-import java.util.List;
-
+import com.citytechinc.cq.component.touchuidialog.TouchUIDialogType;
 import com.citytechinc.cq.component.touchuidialog.widget.DefaultTouchUIWidgetParameters;
 import com.citytechinc.cq.component.touchuidialog.widget.datasource.DataSource;
 import com.citytechinc.cq.component.touchuidialog.widget.selection.options.Option;
 import com.citytechinc.cq.component.touchuidialog.widget.selection.options.Options;
 import com.citytechinc.cq.component.touchuidialog.widget.selection.options.OptionsParameters;
 import com.citytechinc.cq.component.xml.XmlElement;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class RadioGroupWidgetParameters extends DefaultTouchUIWidgetParameters {
 
@@ -90,6 +91,9 @@ public class RadioGroupWidgetParameters extends DefaultTouchUIWidgetParameters {
 
 	@Override
 	public String getResourceType() {
+		if(TouchUIDialogType.CORAL3.isOfType(getTouchUIDialogType())) {
+			return RadioGroupCoral3Widget.RESOURCE_TYPE;
+		}
 		return RadioGroupWidget.RESOURCE_TYPE;
 	}
 

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/selection/SelectionFieldCoral3Widget.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/selection/SelectionFieldCoral3Widget.java
@@ -1,0 +1,39 @@
+/**
+ *    Copyright 2017 ICF Olson
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.citytechinc.cq.component.touchuidialog.widget.selection;
+
+import com.citytechinc.cq.component.annotations.config.TouchUIWidget;
+import com.citytechinc.cq.component.annotations.widgets.Selection;
+import com.citytechinc.cq.component.touchuidialog.widget.AbstractTouchUIWidget;
+
+@TouchUIWidget(annotationClass = Selection.class, makerClass = SelectionFieldWidgetMaker.class,
+	resourceType = SelectionFieldCoral3Widget.RESOURCE_TYPE)
+public class SelectionFieldCoral3Widget extends AbstractTouchUIWidget {
+
+	public static final String RESOURCE_TYPE = "granite/ui/components/coral/foundation/form/select";
+
+	private final boolean multiple;
+
+	public SelectionFieldCoral3Widget(SelectionFieldWidgetParameters parameters) {
+		super(parameters);
+
+		this.multiple = parameters.isMultiple();
+	}
+
+	public boolean getMultiple() {
+		return multiple;
+	}
+}

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/selection/SelectionFieldWidgetMaker.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/selection/SelectionFieldWidgetMaker.java
@@ -15,6 +15,7 @@
  */
 package com.citytechinc.cq.component.touchuidialog.widget.selection;
 
+import com.citytechinc.cq.component.touchuidialog.TouchUIDialogType;
 import org.codehaus.plexus.util.StringUtils;
 
 import com.citytechinc.cq.component.annotations.widgets.Selection;
@@ -71,12 +72,17 @@ public class SelectionFieldWidgetMaker extends AbstractTouchUIWidgetMaker<Select
 
 		widgetParameters.setMultiple(getMultipleForField(selectionField));
 		widgetParameters.setDataSource(getDataSourceForField(selectionField));
+		widgetParameters.setTouchUIDialogType(parameters.getTouchUIDialogType());
 
         if(widgetParameters.getDataSource() == null) {
             widgetParameters.setOptions(TouchUIDialogUtil
                 .getOptionsForSelection(selectionField, getType(), parameters.getClassLoader(),
                     parameters.getClassPool()));
         }
+
+        if(TouchUIDialogType.CORAL3.isOfType(widgetParameters.getTouchUIDialogType())) {
+        	return new SelectionFieldCoral3Widget(widgetParameters);
+		}
 		return new SelectionFieldWidget(widgetParameters);
 	}
 

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/selection/SelectionFieldWidgetParameters.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/selection/SelectionFieldWidgetParameters.java
@@ -15,15 +15,16 @@
  */
 package com.citytechinc.cq.component.touchuidialog.widget.selection;
 
-import java.util.ArrayList;
-import java.util.List;
-
+import com.citytechinc.cq.component.touchuidialog.TouchUIDialogType;
 import com.citytechinc.cq.component.touchuidialog.widget.DefaultTouchUIWidgetParameters;
 import com.citytechinc.cq.component.touchuidialog.widget.datasource.DataSource;
 import com.citytechinc.cq.component.touchuidialog.widget.selection.options.Option;
 import com.citytechinc.cq.component.touchuidialog.widget.selection.options.Options;
 import com.citytechinc.cq.component.touchuidialog.widget.selection.options.OptionsParameters;
 import com.citytechinc.cq.component.xml.XmlElement;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class SelectionFieldWidgetParameters extends DefaultTouchUIWidgetParameters {
 
@@ -91,6 +92,9 @@ public class SelectionFieldWidgetParameters extends DefaultTouchUIWidgetParamete
 
 	@Override
 	public String getResourceType() {
+		if(TouchUIDialogType.CORAL3.isOfType(getTouchUIDialogType())){
+			return SelectionFieldCoral3Widget.RESOURCE_TYPE;
+		}
 		return SelectionFieldWidget.RESOURCE_TYPE;
 	}
 

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/switchwidget/SwitchCoral3Widget.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/switchwidget/SwitchCoral3Widget.java
@@ -1,0 +1,57 @@
+/**
+ *    Copyright 2017 ICF Olson
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.citytechinc.cq.component.touchuidialog.widget.switchwidget;
+
+import com.citytechinc.cq.component.annotations.config.TouchUIWidget;
+import com.citytechinc.cq.component.annotations.widgets.Switch;
+import com.citytechinc.cq.component.touchuidialog.widget.AbstractTouchUIWidget;
+
+@TouchUIWidget(annotationClass = Switch.class, makerClass = SwitchWidgetMaker.class,
+	resourceType = SwitchCoral3Widget.RESOURCE_TYPE)
+public class SwitchCoral3Widget extends AbstractTouchUIWidget {
+
+	public static final String RESOURCE_TYPE = "granite/ui/components/coral/foundation/form/switch";
+
+	private final String onText;
+	private final String offText;
+	private final Boolean checked;
+	private final boolean ignoreData;
+
+	public SwitchCoral3Widget(SwitchWidgetParameters parameters) {
+		super(parameters);
+		this.onText = parameters.getOnText();
+		this.offText = parameters.getOffText();
+		this.checked = parameters.getChecked();
+		this.ignoreData = parameters.isIgnoreData();
+	}
+
+	public String getOnText() {
+		return onText;
+	}
+
+	public String getOffText() {
+		return offText;
+	}
+
+	public Boolean getChecked() {
+		return checked;
+	}
+
+	public boolean isIgnoreData() {
+		return ignoreData;
+	}
+
+}

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/switchwidget/SwitchWidgetMaker.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/switchwidget/SwitchWidgetMaker.java
@@ -15,6 +15,7 @@
  */
 package com.citytechinc.cq.component.touchuidialog.widget.switchwidget;
 
+import com.citytechinc.cq.component.touchuidialog.TouchUIDialogType;
 import org.codehaus.plexus.util.StringUtils;
 
 import com.citytechinc.cq.component.annotations.widgets.Switch;
@@ -39,7 +40,11 @@ public class SwitchWidgetMaker extends AbstractTouchUIWidgetMaker<SwitchWidgetPa
 		widgetParameters.setOffText(getOffTextForField(switchAnnotation));
 		widgetParameters.setChecked(getCheckedForField(switchAnnotation));
 		widgetParameters.setIgnoreData(getIgnoreDataField(switchAnnotation));
+		widgetParameters.setTouchUIDialogType(parameters.getTouchUIDialogType());
 
+		if(TouchUIDialogType.CORAL3.isOfType(widgetParameters.getTouchUIDialogType())) {
+			return new SwitchCoral3Widget(widgetParameters);
+		}
 		return new SwitchWidget(widgetParameters);
 	}
 

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/switchwidget/SwitchWidgetParameters.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/switchwidget/SwitchWidgetParameters.java
@@ -15,6 +15,7 @@
  */
 package com.citytechinc.cq.component.touchuidialog.widget.switchwidget;
 
+import com.citytechinc.cq.component.touchuidialog.TouchUIDialogType;
 import com.citytechinc.cq.component.touchuidialog.widget.DefaultTouchUIWidgetParameters;
 
 public class SwitchWidgetParameters extends DefaultTouchUIWidgetParameters {
@@ -58,6 +59,9 @@ public class SwitchWidgetParameters extends DefaultTouchUIWidgetParameters {
 
 	@Override
 	public String getResourceType() {
+		if(TouchUIDialogType.CORAL3.isOfType(getTouchUIDialogType())) {
+			return SwitchCoral3Widget.RESOURCE_TYPE;
+		}
 		return SwitchWidget.RESOURCE_TYPE;
 	}
 

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/taginputfield/TagInputFieldCoral3Widget.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/taginputfield/TagInputFieldCoral3Widget.java
@@ -1,0 +1,34 @@
+/**
+ *    Copyright 2017 ICF Olson
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.citytechinc.cq.component.touchuidialog.widget.taginputfield;
+
+import com.citytechinc.cq.component.annotations.config.TouchUIWidget;
+import com.citytechinc.cq.component.annotations.widgets.TagInputField;
+import com.citytechinc.cq.component.touchuidialog.widget.autocomplete.AutoCompleteCoral3Widget;
+import com.citytechinc.cq.component.touchuidialog.widget.autocomplete.AutoCompleteWidgetParameters;
+
+@TouchUIWidget(annotationClass = TagInputField.class, makerClass = TagInputFieldWidgetMaker.class,
+	resourceType = TagInputFieldCoral3Widget.RESOURCE_TYPE)
+public class TagInputFieldCoral3Widget extends AutoCompleteCoral3Widget {
+
+	public static final String VALUES_RESOURCE_TYPE = "granite/ui/components/coral/foundation/form/autocomplete/tags";
+	public static final String OPTIONS_RESOURCE_TYPE = "granite/ui/components/coral/foundation/form/autocomplete/list";
+
+	public TagInputFieldCoral3Widget(AutoCompleteWidgetParameters parameters) {
+		super(parameters);
+	}
+
+}

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/taginputfield/TagInputFieldWidget.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/taginputfield/TagInputFieldWidget.java
@@ -19,7 +19,6 @@ import com.citytechinc.cq.component.annotations.config.TouchUIWidget;
 import com.citytechinc.cq.component.annotations.widgets.TagInputField;
 import com.citytechinc.cq.component.touchuidialog.widget.autocomplete.AutoCompleteWidget;
 import com.citytechinc.cq.component.touchuidialog.widget.autocomplete.AutoCompleteWidgetParameters;
-import com.citytechinc.cq.component.touchuidialog.widget.tagspicker.TagsPickerWidget;
 
 @TouchUIWidget(annotationClass = TagInputField.class, makerClass = TagInputFieldWidgetMaker.class,
 	resourceType = TagInputFieldWidget.RESOURCE_TYPE)

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/taginputfield/TagInputFieldWidgetMaker.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/taginputfield/TagInputFieldWidgetMaker.java
@@ -15,13 +15,11 @@
  */
 package com.citytechinc.cq.component.touchuidialog.widget.taginputfield;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import com.citytechinc.cq.component.annotations.TagNameSpace;
 import com.citytechinc.cq.component.annotations.widgets.TagInputField;
 import com.citytechinc.cq.component.touchuidialog.DefaultTouchUIDialogElementParameters;
 import com.citytechinc.cq.component.touchuidialog.TouchUIDialogElementParameters;
+import com.citytechinc.cq.component.touchuidialog.TouchUIDialogType;
 import com.citytechinc.cq.component.touchuidialog.widget.autocomplete.AutoCompleteWidgetMaker;
 import com.citytechinc.cq.component.touchuidialog.widget.autocomplete.options.AutoCompleteOptions;
 import com.citytechinc.cq.component.touchuidialog.widget.autocomplete.values.AutoCompleteValues;
@@ -29,6 +27,9 @@ import com.citytechinc.cq.component.touchuidialog.widget.datasource.DataSource;
 import com.citytechinc.cq.component.touchuidialog.widget.maker.TouchUIWidgetMakerParameters;
 import com.citytechinc.cq.component.touchuidialog.widget.taginputfield.datasource.TagsDataSource;
 import com.citytechinc.cq.component.touchuidialog.widget.taginputfield.datasource.TagsDataSourceParameters;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class TagInputFieldWidgetMaker extends AutoCompleteWidgetMaker {
 
@@ -64,7 +65,11 @@ public class TagInputFieldWidgetMaker extends AutoCompleteWidgetMaker {
 	protected AutoCompleteOptions makeOptions() {
 		TouchUIDialogElementParameters optionsParameters = new DefaultTouchUIDialogElementParameters();
 
-		optionsParameters.setResourceType(TagInputFieldWidget.OPTIONS_RESOURCE_TYPE);
+		if(TouchUIDialogType.CORAL3.isOfType(parameters.getTouchUIDialogType())){
+			optionsParameters.setResourceType(TagInputFieldCoral3Widget.OPTIONS_RESOURCE_TYPE);
+		} else {
+			optionsParameters.setResourceType(TagInputFieldWidget.OPTIONS_RESOURCE_TYPE);
+		}
 		optionsParameters.setFieldName(TagInputFieldWidget.OPTIONS_FIELD_NAME);
 		optionsParameters.setPrimaryType("nt:unstructured");
 
@@ -75,7 +80,11 @@ public class TagInputFieldWidgetMaker extends AutoCompleteWidgetMaker {
 	protected AutoCompleteValues makeValues() {
 		TouchUIDialogElementParameters valuesParameters = new DefaultTouchUIDialogElementParameters();
 
-		valuesParameters.setResourceType(TagInputFieldWidget.VALUES_RESOURCE_TYPE);
+		if(TouchUIDialogType.CORAL3.isOfType(parameters.getTouchUIDialogType())){
+			valuesParameters.setResourceType(TagInputFieldCoral3Widget.VALUES_RESOURCE_TYPE);
+		} else {
+			valuesParameters.setResourceType(TagInputFieldWidget.VALUES_RESOURCE_TYPE);
+		}
 		valuesParameters.setFieldName(TagInputFieldWidget.VALUES_FIELD_NAME);
 		valuesParameters.setPrimaryType("nt:unstructured");
 

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/textarea/TextAreaCoral3Widget.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/textarea/TextAreaCoral3Widget.java
@@ -1,0 +1,54 @@
+/**
+ *    Copyright 2017 ICF Olson
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.citytechinc.cq.component.touchuidialog.widget.textarea;
+
+import com.citytechinc.cq.component.annotations.config.TouchUIWidget;
+import com.citytechinc.cq.component.annotations.widgets.TextArea;
+import com.citytechinc.cq.component.touchuidialog.widget.AbstractTouchUIWidget;
+
+@TouchUIWidget(annotationClass = TextArea.class, makerClass = TextAreaWidgetMaker.class,
+	resourceType = TextAreaCoral3Widget.RESOURCE_TYPE)
+public class TextAreaCoral3Widget extends AbstractTouchUIWidget {
+
+	public static final String RESOURCE_TYPE = "granite/ui/components/coral/foundation/form/textarea";
+
+	private final Integer cols;
+	private final Integer rows;
+	private final String resize;
+
+	public TextAreaCoral3Widget(TextAreaWidgetParameters parameters) {
+
+		super(parameters);
+
+		this.cols = parameters.getCols();
+		this.rows = parameters.getRows();
+		this.resize = parameters.getResize();
+
+	}
+
+	public Integer getCols() {
+		return cols;
+	}
+
+	public Integer getRows() {
+		return rows;
+	}
+
+	public String getResize() {
+		return resize;
+	}
+
+}

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/textarea/TextAreaWidgetMaker.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/textarea/TextAreaWidgetMaker.java
@@ -15,6 +15,7 @@
  */
 package com.citytechinc.cq.component.touchuidialog.widget.textarea;
 
+import com.citytechinc.cq.component.touchuidialog.TouchUIDialogType;
 import org.codehaus.plexus.util.StringUtils;
 
 import com.citytechinc.cq.component.annotations.widgets.TextArea;
@@ -40,7 +41,11 @@ public class TextAreaWidgetMaker extends AbstractTouchUIWidgetMaker<TextAreaWidg
 		widgetParameters.setCols(getColsForField(widgetAnnotation));
 		widgetParameters.setRows(getRowsForField(widgetAnnotation));
 		widgetParameters.setResize(getResizeForField(widgetAnnotation));
+		widgetParameters.setTouchUIDialogType(parameters.getTouchUIDialogType());
 
+		if(TouchUIDialogType.CORAL3.isOfType(widgetParameters.getTouchUIDialogType())){
+			return new TextAreaCoral3Widget(widgetParameters);
+		}
 		return new TextAreaWidget(widgetParameters);
 
 	}

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/textarea/TextAreaWidgetParameters.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/textarea/TextAreaWidgetParameters.java
@@ -15,6 +15,7 @@
  */
 package com.citytechinc.cq.component.touchuidialog.widget.textarea;
 
+import com.citytechinc.cq.component.touchuidialog.TouchUIDialogType;
 import com.citytechinc.cq.component.touchuidialog.widget.DefaultTouchUIWidgetParameters;
 
 public class TextAreaWidgetParameters extends DefaultTouchUIWidgetParameters {
@@ -49,6 +50,9 @@ public class TextAreaWidgetParameters extends DefaultTouchUIWidgetParameters {
 
 	@Override
 	public String getResourceType() {
+		if(TouchUIDialogType.CORAL3.isOfType(getTouchUIDialogType())){
+			return TextAreaCoral3Widget.RESOURCE_TYPE;
+		}
 		return TextAreaWidget.RESOURCE_TYPE;
 	}
 

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/textfield/TextFieldCoral3Widget.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/textfield/TextFieldCoral3Widget.java
@@ -1,0 +1,32 @@
+/**
+ *    Copyright 2017 ICF Olson
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.citytechinc.cq.component.touchuidialog.widget.textfield;
+
+import com.citytechinc.cq.component.annotations.config.TouchUIWidget;
+import com.citytechinc.cq.component.annotations.widgets.TextField;
+import com.citytechinc.cq.component.touchuidialog.widget.AbstractTouchUIWidget;
+import com.citytechinc.cq.component.touchuidialog.widget.DefaultTouchUIWidgetParameters;
+
+@TouchUIWidget(annotationClass = TextField.class, makerClass = TextFieldWidgetMaker.class,
+	resourceType = TextFieldCoral3Widget.RESOURCE_TYPE)
+public class TextFieldCoral3Widget extends AbstractTouchUIWidget {
+
+	public static final String RESOURCE_TYPE = "granite/ui/components/coral/foundation/form/textfield";
+
+	public TextFieldCoral3Widget(DefaultTouchUIWidgetParameters parameters) {
+		super(parameters);
+	}
+}

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/textfield/TextFieldWidgetMaker.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/textfield/TextFieldWidgetMaker.java
@@ -16,20 +16,23 @@
 package com.citytechinc.cq.component.touchuidialog.widget.textfield;
 
 import com.citytechinc.cq.component.touchuidialog.TouchUIDialogElement;
-import com.citytechinc.cq.component.touchuidialog.widget.DefaultTouchUIWidgetParameters;
+import com.citytechinc.cq.component.touchuidialog.TouchUIDialogType;
 import com.citytechinc.cq.component.touchuidialog.widget.maker.AbstractTouchUIWidgetMaker;
 import com.citytechinc.cq.component.touchuidialog.widget.maker.TouchUIWidgetMakerParameters;
 
-public class TextFieldWidgetMaker extends AbstractTouchUIWidgetMaker<DefaultTouchUIWidgetParameters> {
+public class TextFieldWidgetMaker extends AbstractTouchUIWidgetMaker<TextFieldWidgetParameters> {
 
 	public TextFieldWidgetMaker(TouchUIWidgetMakerParameters parameters) {
 		super(parameters);
 	}
 
 	@Override
-	public TouchUIDialogElement make(DefaultTouchUIWidgetParameters widgetParameters) {
-		widgetParameters.setResourceType(TextFieldWidget.RESOURCE_TYPE);
+	public TouchUIDialogElement make(TextFieldWidgetParameters widgetParameters) {
+		widgetParameters.setTouchUIDialogType(parameters.getTouchUIDialogType());
+
+		if(TouchUIDialogType.CORAL3.isOfType(widgetParameters.getTouchUIDialogType())) {
+			return new TextFieldCoral3Widget(widgetParameters);
+		}
 		return new TextFieldWidget(widgetParameters);
 	}
-
 }

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/textfield/TextFieldWidgetParameters.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/textfield/TextFieldWidgetParameters.java
@@ -1,0 +1,30 @@
+/**
+ *    Copyright 2017 ICF Olson
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.citytechinc.cq.component.touchuidialog.widget.textfield;
+
+import com.citytechinc.cq.component.touchuidialog.TouchUIDialogType;
+import com.citytechinc.cq.component.touchuidialog.widget.DefaultTouchUIWidgetParameters;
+
+public class TextFieldWidgetParameters extends DefaultTouchUIWidgetParameters {
+
+	@Override
+	public String getResourceType() {
+		if(TouchUIDialogType.CORAL3.isOfType(getTouchUIDialogType())) {
+			return TextFieldCoral3Widget.RESOURCE_TYPE;
+		}
+		return TextFieldWidget.RESOURCE_TYPE;
+	}
+}

--- a/src/site/markdown/usage.md
+++ b/src/site/markdown/usage.md
@@ -87,6 +87,42 @@ Numberfield saved as ./quantity
     @NumberField(allowNegative=false, allowDecimals=true)
     private Double quantity;
 
+Composite Multifield (CoralUI 3 only) saved as ./compositeMultifield
+
+    @DialogField(fieldLabel = "Composite Multifield")
+    @MultiField(composite = true)
+    protected List<ContactData> compositeMultifield;
+        
+    // ContactData class example
+    public class ContactData {
+        @DialogField(fieldLabel = "First Name")
+        @TextField
+        private String firstName;
+        
+        @DialogField(fieldLabel = "Last Name")
+        @TextField
+        private String lastName;
+        
+        @DialogField(fieldLabel = "Phone Number")
+        @TextField
+        private String phoneNumber;
+        
+        @DialogField
+        @MultiFieldChildResource
+        private Address address;
+    }
+        
+    // Address class example
+    public class Address {
+        @DialogField(fieldLabel = "Street Name", name = "./address/streetName")
+        @TextField
+        private String streetName;
+        
+        @DialogField(fieldLabel = "Street Number", name = "./address/streetNumber")
+        @TextField
+        private String streetNumber;
+    }
+
 ### In Place Editors
 In Place Editor specific annotations are used to configure in place editors inside the cq:editConfig.xml.  If multiple in place editor annotations are found for a given class, a hybrid in place editor is configured using the provided individual configurations.
 
@@ -184,6 +220,11 @@ Generation of the Touch UI dialogs can be suppressed at a project, component, or
 project level set the `generateTouchUiDialogs` POM configuration to `false`.  To suppress generation at a component 
 level, set the `suppressTouchUIDialog` attribute of the `@Component` annotation to `false`.  To suppress generation at 
 a field level, set the `suppressTouchUI` attribute of the `@DialogField` annotation to `false`. 
+
+### Enabling Touch UI CoralUI 3 Dialogs
+
+Generation of the Touch UI CoralUI 3 dialogs can be enabled at a project level. In order to enable it,
+set the `useCoral3Dialogs` POM configuration to `true`. CoralUI 3 dialogs are currently tested with AEM 6.3.
 
 ### Disabling Classic UI 
 


### PR DESCRIPTION
Added possibility to create TouchUI CoralUI 3 dialogs that can be used on AEM 6.3:

- added new pom parameter "useCoral3Dialogs"
- added coralui 3 layouts (fixed column, tabs)
- added coralui 3 widgets (textfield, autocomplete, checkbox, datefield, datetime, fieldset, fileupload, multifield, numberfield, pathfield, radio, select, switch, tag input field, textarea)