### PR TITLE
Fix for file upload widgets nested in dialog field set

### DIFF
--- a/cq-component-annotations/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/maker/TouchUIWidgetMakerParameters.java
+++ b/cq-component-annotations/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/maker/TouchUIWidgetMakerParameters.java
@@ -30,6 +30,7 @@ public class TouchUIWidgetMakerParameters {
 	private String resourceType;
 	private boolean useDotSlashInName;
 	private TouchUIWidgetRegistry widgetRegistry;
+	private String relativePath;
 
 	public DialogFieldConfig getDialogFieldConfig() {
 		return dialogFieldConfig;
@@ -93,5 +94,13 @@ public class TouchUIWidgetMakerParameters {
 
 	public void setWidgetRegistry(TouchUIWidgetRegistry widgetRegistry) {
 		this.widgetRegistry = widgetRegistry;
+	}
+
+	public String getRelativePath() {
+		return relativePath;
+	}
+
+	public void setRelativePath(String relativePath) {
+		this.relativePath = relativePath;
 	}
 }

--- a/cq-component-annotations/src/main/java/com/citytechinc/cq/component/util/NameUtil.java
+++ b/cq-component-annotations/src/main/java/com/citytechinc/cq/component/util/NameUtil.java
@@ -1,0 +1,27 @@
+/**
+ *    Copyright 2017 ICF Olson
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.citytechinc.cq.component.util;
+
+public final class NameUtil {
+
+    public static String normalizeName(String name, boolean useDotSlash) {
+        String unformattedName = useDotSlash ? "./" + name : name;
+        return unformattedName.replaceAll("(/+[\\./]+/+)", "/");
+    }
+
+    private NameUtil() { }
+
+}

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/dialogfieldset/DialogFieldSetWidgetMaker.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/dialogfieldset/DialogFieldSetWidgetMaker.java
@@ -104,6 +104,8 @@ public class DialogFieldSetWidgetMaker extends AbstractTouchUIWidgetMaker<Dialog
                     }
                 }
 
+
+
                 if (dialogFieldConfig != null && !dialogFieldConfig.isSuppressTouchUI()) {
                     if (StringUtils.isNotBlank(dialogFieldSetAnnotation.namePrefix())) {
                         String name = dialogFieldConfig.getName();
@@ -128,6 +130,7 @@ public class DialogFieldSetWidgetMaker extends AbstractTouchUIWidgetMaker<Dialog
                     curFieldMember.setClassPool(parameters.getClassPool());
                     curFieldMember.setWidgetRegistry(parameters.getWidgetRegistry());
                     curFieldMember.setUseDotSlashInName(parameters.isUseDotSlashInName());
+                    curFieldMember.setRelativePath(dialogFieldSetAnnotation.namePrefix());
 
                     TouchUIDialogElement currentDialogElement = TouchUIWidgetFactory.make(curFieldMember, -1);
 

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/fileupload/FileUploadWidget.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/fileupload/FileUploadWidget.java
@@ -15,11 +15,11 @@
  */
 package com.citytechinc.cq.component.touchuidialog.widget.fileupload;
 
-import java.util.List;
-
 import com.citytechinc.cq.component.annotations.config.TouchUIWidget;
 import com.citytechinc.cq.component.annotations.widgets.Html5SmartFile;
 import com.citytechinc.cq.component.touchuidialog.widget.AbstractTouchUIWidget;
+
+import java.util.List;
 
 @TouchUIWidget(annotationClass = Html5SmartFile.class, makerClass = FileUploadWidgetMaker.class,
 	resourceType = FileUploadWidget.RESOURCE_TYPE)
@@ -37,6 +37,8 @@ public class FileUploadWidget extends AbstractTouchUIWidget {
 	private final boolean autoStart;
 	private final boolean useHTML5;
 	private final String dropZone;
+	private final String fileNameParameter;
+	private final String fileReferenceParameter;
 	// TODO: Event handling ?
 	private final List<String> mimeTypes;
 
@@ -52,6 +54,8 @@ public class FileUploadWidget extends AbstractTouchUIWidget {
 		autoStart = parameters.isAutoStart();
 		useHTML5 = parameters.isUseHTML5();
 		dropZone = parameters.getDropZone();
+		fileNameParameter = parameters.getFileNameParameter();
+		fileReferenceParameter = parameters.getFileReferenceParameter();
 		mimeTypes = parameters.getMimeTypes();
 	}
 
@@ -94,6 +98,14 @@ public class FileUploadWidget extends AbstractTouchUIWidget {
 
 	public String getDropZone() {
 		return dropZone;
+	}
+
+	public String getFileNameParameter() {
+		return fileNameParameter;
+	}
+
+	public String getFileReferenceParameter() {
+		return fileReferenceParameter;
 	}
 
 	public List<String> getMimeTypes() {

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/fileupload/FileUploadWidgetMaker.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/fileupload/FileUploadWidgetMaker.java
@@ -15,17 +15,17 @@
  */
 package com.citytechinc.cq.component.touchuidialog.widget.fileupload;
 
-import java.util.Arrays;
-import java.util.List;
-
-import org.codehaus.plexus.util.StringUtils;
-
 import com.citytechinc.cq.component.annotations.widgets.Html5SmartFile;
 import com.citytechinc.cq.component.dialog.exception.InvalidComponentFieldException;
 import com.citytechinc.cq.component.touchuidialog.TouchUIDialogElement;
 import com.citytechinc.cq.component.touchuidialog.exceptions.TouchUIDialogGenerationException;
 import com.citytechinc.cq.component.touchuidialog.widget.maker.AbstractTouchUIWidgetMaker;
 import com.citytechinc.cq.component.touchuidialog.widget.maker.TouchUIWidgetMakerParameters;
+import com.citytechinc.cq.component.util.NameUtil;
+import org.codehaus.plexus.util.StringUtils;
+
+import java.util.Arrays;
+import java.util.List;
 
 public class FileUploadWidgetMaker extends AbstractTouchUIWidgetMaker<FileUploadWidgetParameters> {
 
@@ -48,6 +48,8 @@ public class FileUploadWidgetMaker extends AbstractTouchUIWidgetMaker<FileUpload
 		widgetParameters.setAutoStart(getAutoStartForField(smartFileAnnotation));
 		widgetParameters.setUseHTML5(getUseHTML5ForField(smartFileAnnotation));
 		widgetParameters.setDropZone(getDropZoneForField(smartFileAnnotation));
+		widgetParameters.setFileNameParameter(getFileNameParameterForField(smartFileAnnotation));
+		widgetParameters.setFileReferenceParameter(getFileReferenceParameterForField(smartFileAnnotation));
 		widgetParameters.setMimeTypes(getMimeTypesForField(smartFileAnnotation));
 
 		return new FileUploadWidget(widgetParameters);
@@ -87,7 +89,27 @@ public class FileUploadWidgetMaker extends AbstractTouchUIWidgetMaker<FileUpload
 
 	public String getFileNameParameterForField(Html5SmartFile annotation) {
 		if (annotation != null && StringUtils.isNotBlank(annotation.fileNameParameter())) {
-			return annotation.fileNameParameter();
+			String parameter = annotation.fileNameParameter();
+			String relativePath = parameters.getRelativePath();
+			if (relativePath != null) {
+				boolean useDotSlash = parameters.isUseDotSlashInName();
+				parameter = NameUtil.normalizeName(relativePath + parameter, useDotSlash);
+			}
+			return parameter;
+		}
+
+		return null;
+	}
+
+	public String getFileReferenceParameterForField(Html5SmartFile annotation) {
+		if (annotation != null && StringUtils.isNotBlank(annotation.fileNameParameter())) {
+			String parameter = annotation.fileReferenceParameter();
+			String relativePath = parameters.getRelativePath();
+			if (relativePath != null) {
+				boolean useDotSlash = parameters.isUseDotSlashInName();
+				parameter = NameUtil.normalizeName(relativePath + parameter, useDotSlash);
+			}
+			return parameter;
 		}
 
 		return null;

--- a/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/fileupload/FileUploadWidgetParameters.java
+++ b/cq-component-maven-plugin/src/main/java/com/citytechinc/cq/component/touchuidialog/widget/fileupload/FileUploadWidgetParameters.java
@@ -15,9 +15,9 @@
  */
 package com.citytechinc.cq.component.touchuidialog.widget.fileupload;
 
-import java.util.List;
-
 import com.citytechinc.cq.component.touchuidialog.widget.DefaultTouchUIWidgetParameters;
+
+import java.util.List;
 
 public class FileUploadWidgetParameters extends DefaultTouchUIWidgetParameters {
 
@@ -31,6 +31,8 @@ public class FileUploadWidgetParameters extends DefaultTouchUIWidgetParameters {
 	private boolean autoStart;
 	private boolean useHTML5;
 	private String dropZone;
+	private String fileNameParameter;
+	private String fileReferenceParameter;
 	// TODO: Event handling
 	private List<String> mimeTypes;
 
@@ -114,6 +116,22 @@ public class FileUploadWidgetParameters extends DefaultTouchUIWidgetParameters {
 
 	public void setDropZone(String dropZone) {
 		this.dropZone = dropZone;
+	}
+
+	public String getFileNameParameter() {
+		return fileNameParameter;
+	}
+
+	public void setFileNameParameter(String fileNameParameter) {
+		this.fileNameParameter = fileNameParameter;
+	}
+
+	public String getFileReferenceParameter() {
+		return fileReferenceParameter;
+	}
+
+	public void setFileReferenceParameter(String fileReferenceParameter) {
+		this.fileReferenceParameter = fileReferenceParameter;
 	}
 
 	public List<String> getMimeTypes() {


### PR DESCRIPTION
Corrects fileReferenceParameter and fileNameParameter fields with the relative path provided by a parent dialog field set.  This prevents name collisions when multiple file uploads exist within the same dialog field set.